### PR TITLE
Fix default storage location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ bin/*
 .rosetta-data
 .avalanchego
 *.swp
+mainnet-data
+testnet-data

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,4 @@ bin/*
 .rosetta-data
 .avalanchego
 *.swp
-mainnet-data
-testnet-data
+data

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ run-testnet:
 	docker run \
 		--rm \
 		-d \
-		-v ${WORKDIR}/testnet-data:/data \
+		-v ${WORKDIR}/data:/data \
 		-e AVALANCHE_NETWORK=Fuji \
 		-e AVALANCHE_CHAIN=43113 \
 		-e AVALANCHE_MODE=online \
@@ -66,7 +66,7 @@ run-mainnet:
 	docker run \
 		--rm \
 		-d \
-		-v ${WORKDIR}/mainnet-data:/data \
+		-v ${WORKDIR}/data:/data \
 		-e AVALANCHE_NETWORK=Mainnet \
 		-e AVALANCHE_CHAIN=43114 \
 		-e AVALANCHE_MODE=online \

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ run-testnet:
 	docker run \
 		--rm \
 		-d \
-		-v ${WORKDIR}/.avalanchego:/root/.avalanchego \
+		-v ${WORKDIR}/testnet-data:/data \
 		-e AVALANCHE_NETWORK=Fuji \
 		-e AVALANCHE_CHAIN=43113 \
 		-e AVALANCHE_MODE=online \
@@ -66,7 +66,7 @@ run-mainnet:
 	docker run \
 		--rm \
 		-d \
-		-v ${WORKDIR}/.avalanchego:/root/.avalanchego \
+		-v ${WORKDIR}/mainnet-data:/data \
 		-e AVALANCHE_NETWORK=Mainnet \
 		-e AVALANCHE_CHAIN=43114 \
 		-e AVALANCHE_MODE=online \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,6 +13,7 @@ cat <<EOF > /app/avalanchego-config.json
   "api-admin-enabled": false,
   "api-ipcs-enabled": false,
   "api-keystore-enabled": false,
+  "db-dir": "/data",
   "chain-config-dir": "/app/configs/chains"
 }
 EOF


### PR DESCRIPTION
The Rosetta API spec states persistent data must be stored at `/data` (we were storing at `/root/.avalanchego`): https://www.rosetta-api.org/docs/standard_storage_location.html