### PR TITLE
V1.4.11 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ DOCKER_ORG          ?= avaplatform
 DOCKER_IMAGE        ?= ${DOCKER_ORG}/${PROJECT}
 DOCKER_LABEL        ?= latest
 DOCKER_TAG          ?= ${DOCKER_IMAGE}:${DOCKER_LABEL}
-AVALANCHE_VERSION   ?= v1.4.10
+AVALANCHE_VERSION   ?= v1.4.11
 
 build:
 	go build -o ./rosetta-server ./cmd/server

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.15
 
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
-	github.com/ava-labs/avalanchego v1.4.10
-	github.com/ava-labs/coreth v0.5.5-rc.1
+	github.com/ava-labs/avalanchego v1.4.11
+	github.com/ava-labs/coreth v0.5.6-rc.6
 	github.com/coinbase/rosetta-sdk-go v0.6.5
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0 // indirect
 	github.com/ethereum/go-ethereum v1.10.3

--- a/go.sum
+++ b/go.sum
@@ -74,11 +74,11 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
-github.com/ava-labs/avalanchego v1.4.10-rc.2.0.20210709143805-175525cb0570/go.mod h1:V9qJp9RYUApCmGASsfTlYt+/569tuDX8MrF4j3E+oT8=
-github.com/ava-labs/avalanchego v1.4.10 h1:YMtdyqGcrydyo0ss0ie0t0EtWAwca8FF5zLbqT8qN/8=
-github.com/ava-labs/avalanchego v1.4.10/go.mod h1:V9qJp9RYUApCmGASsfTlYt+/569tuDX8MrF4j3E+oT8=
-github.com/ava-labs/coreth v0.5.5-rc.1 h1:YgsF0VN9BNZNavZoV6yzj5ZLQAOdF910E1kNW6rKhtY=
-github.com/ava-labs/coreth v0.5.5-rc.1/go.mod h1:3wW2lo9EXmhRjv1jXmtISriH9BtWG7jYgVwmiLKtr8o=
+github.com/ava-labs/avalanchego v1.4.11-rc.0/go.mod h1:V9qJp9RYUApCmGASsfTlYt+/569tuDX8MrF4j3E+oT8=
+github.com/ava-labs/avalanchego v1.4.11 h1:bPj+Zj19owlGDfC4FiZ5oQj6v5xhg41qPRd7JYZG8ws=
+github.com/ava-labs/avalanchego v1.4.11/go.mod h1:aleAWKvMQ/mblB4dXWWvlbq8787TmwR7+3WizYtogTM=
+github.com/ava-labs/coreth v0.5.6-rc.6 h1:ORsn8SU0F174z62St7dTmBN9fOEn7cpIiN67hdkIWvY=
+github.com/ava-labs/coreth v0.5.6-rc.6/go.mod h1:OaNz0OsOhTtk4U4dVWstdRnOxbeY0IJZYk9vKh+FXFo=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
@@ -250,6 +250,7 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/geo v0.0.0-20190916061304-5b978397cfec/go.mod h1:QZ0nwyI2jOfgRAoBvP+ab5aRr7c9x7lhGEJrKvBwjWI=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/service/rosetta.go
+++ b/service/rosetta.go
@@ -1,7 +1,7 @@
 package service
 
 const (
-	NodeVersion       = "1.4.10"
-	MiddlewareVersion = "0.0.4"
+	NodeVersion       = "1.4.11"
+	MiddlewareVersion = "0.0.5"
 	BlockchainName    = "Avalanche"
 )


### PR DESCRIPTION
This PR updates `avalanchego` to [`v1.4.11`](https://github.com/ava-labs/avalanchego/releases/tag/v1.4.11).

Tested on Fuji: 
![image](https://user-images.githubusercontent.com/13023275/127445308-1c1ea940-ccb2-455c-ae64-771f20fa35a3.png)
