### PR TITLE
AvalancheGo@v1.4.12

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 .rosetta-data
 rosetta-server
 rosetta-runner
+data

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ DOCKER_ORG          ?= avaplatform
 DOCKER_IMAGE        ?= ${DOCKER_ORG}/${PROJECT}
 DOCKER_LABEL        ?= latest
 DOCKER_TAG          ?= ${DOCKER_IMAGE}:${DOCKER_LABEL}
-AVALANCHE_VERSION   ?= v1.4.11
+AVALANCHE_VERSION   ?= v1.4.12
 
 build:
 	go build -o ./rosetta-server ./cmd/server

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/ava-labs/avalanchego v1.4.12
-	github.com/ava-labs/coreth v0.5.7-rc.1
+	github.com/ava-labs/coreth v0.5.7
 	github.com/coinbase/rosetta-sdk-go v0.6.5
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0 // indirect
 	github.com/ethereum/go-ethereum v1.10.3

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.15
 
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
-	github.com/ava-labs/avalanchego v1.4.11
-	github.com/ava-labs/coreth v0.5.6-rc.6
+	github.com/ava-labs/avalanchego v1.4.12
+	github.com/ava-labs/coreth v0.5.7-rc.1
 	github.com/coinbase/rosetta-sdk-go v0.6.5
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0 // indirect
 	github.com/ethereum/go-ethereum v1.10.3

--- a/go.sum
+++ b/go.sum
@@ -74,11 +74,10 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
-github.com/ava-labs/avalanchego v1.4.12-rc.2/go.mod h1:aleAWKvMQ/mblB4dXWWvlbq8787TmwR7+3WizYtogTM=
 github.com/ava-labs/avalanchego v1.4.12 h1:nFvjWoBd6CBk90OGreIEUekxTt0x+U17s79bWi/1Ego=
 github.com/ava-labs/avalanchego v1.4.12/go.mod h1:aleAWKvMQ/mblB4dXWWvlbq8787TmwR7+3WizYtogTM=
-github.com/ava-labs/coreth v0.5.7-rc.1 h1:BvCaWH4rgrHzVzOytCtkmIYDgXPssHa+hHEDIJMLYWM=
-github.com/ava-labs/coreth v0.5.7-rc.1/go.mod h1:EPpyvPy/zS352p6xTrhgE3P28oRoBtvUUjM9myjCIno=
+github.com/ava-labs/coreth v0.5.7 h1:qpMhmtdqM/ojk+Ocz2eES6MvIDTppTb03fgqshUxNys=
+github.com/ava-labs/coreth v0.5.7/go.mod h1:z783qZcQOeDtGXz7NwuZc1eWLNKF2EhoHyUheTkJgT8=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=

--- a/go.sum
+++ b/go.sum
@@ -74,11 +74,11 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
-github.com/ava-labs/avalanchego v1.4.11-rc.0/go.mod h1:V9qJp9RYUApCmGASsfTlYt+/569tuDX8MrF4j3E+oT8=
-github.com/ava-labs/avalanchego v1.4.11 h1:bPj+Zj19owlGDfC4FiZ5oQj6v5xhg41qPRd7JYZG8ws=
-github.com/ava-labs/avalanchego v1.4.11/go.mod h1:aleAWKvMQ/mblB4dXWWvlbq8787TmwR7+3WizYtogTM=
-github.com/ava-labs/coreth v0.5.6-rc.6 h1:ORsn8SU0F174z62St7dTmBN9fOEn7cpIiN67hdkIWvY=
-github.com/ava-labs/coreth v0.5.6-rc.6/go.mod h1:OaNz0OsOhTtk4U4dVWstdRnOxbeY0IJZYk9vKh+FXFo=
+github.com/ava-labs/avalanchego v1.4.12-rc.2/go.mod h1:aleAWKvMQ/mblB4dXWWvlbq8787TmwR7+3WizYtogTM=
+github.com/ava-labs/avalanchego v1.4.12 h1:nFvjWoBd6CBk90OGreIEUekxTt0x+U17s79bWi/1Ego=
+github.com/ava-labs/avalanchego v1.4.12/go.mod h1:aleAWKvMQ/mblB4dXWWvlbq8787TmwR7+3WizYtogTM=
+github.com/ava-labs/coreth v0.5.7-rc.1 h1:BvCaWH4rgrHzVzOytCtkmIYDgXPssHa+hHEDIJMLYWM=
+github.com/ava-labs/coreth v0.5.7-rc.1/go.mod h1:EPpyvPy/zS352p6xTrhgE3P28oRoBtvUUjM9myjCIno=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=

--- a/service/rosetta.go
+++ b/service/rosetta.go
@@ -1,7 +1,7 @@
 package service
 
 const (
-	NodeVersion       = "1.4.11"
-	MiddlewareVersion = "0.0.5"
+	NodeVersion       = "1.4.12"
+	MiddlewareVersion = "0.0.6"
 	BlockchainName    = "Avalanche"
 )


### PR DESCRIPTION
This PR updates `avalanchego` to [`v1.4.12`](https://github.com/ava-labs/avalanchego/releases/tag/v1.4.12).