### PR TITLE
Return nonce as hex

### DIFF
--- a/service/service_account.go
+++ b/service/service_account.go
@@ -50,6 +50,20 @@ func (s AccountService) AccountBalance(
 		return nil, wrapError(errInternalError, balanceErr)
 	}
 
+	nonce, nonceErr := s.client.NonceAt(ctx, address, header.Number)
+	if nonceErr != nil {
+		return nil, wrapError(errClientError, nonceErr)
+	}
+
+	metadata := &accountMetadata{
+		Nonce: nonce,
+	}
+
+	metadataMap, metadataErr := marshalJSONMap(metadata)
+	if err != nil {
+		return nil, wrapError(errInternalError, metadataErr)
+	}
+
 	resp := &types.AccountBalanceResponse{
 		BlockIdentifier: &types.BlockIdentifier{
 			Index: header.Number.Int64(),
@@ -58,6 +72,7 @@ func (s AccountService) AccountBalance(
 		Balances: []*types.Amount{
 			mapper.AvaxAmount(balance),
 		},
+		Metadata: metadataMap,
 	}
 
 	return resp, nil

--- a/service/types.go
+++ b/service/types.go
@@ -213,3 +213,34 @@ func (t *transaction) UnmarshalJSON(data []byte) error {
 	t.GasPrice = gasPrice
 	return nil
 }
+
+type accountMetadata struct {
+	Nonce uint64 `json:"nonce"`
+}
+
+type accountMetadataWire struct {
+	Nonce string `json:"nonce"`
+}
+
+func (m *accountMetadata) MarshalJSON() ([]byte, error) {
+	mw := &accountMetadataWire{
+		Nonce: hexutil.Uint64(m.Nonce).String(),
+	}
+
+	return json.Marshal(mw)
+}
+
+func (m *accountMetadata) UnmarshalJSON(data []byte) error {
+	var mw accountMetadataWire
+	if err := json.Unmarshal(data, &mw); err != nil {
+		return err
+	}
+
+	nonce, err := hexutil.DecodeUint64(mw.Nonce)
+	if err != nil {
+		return err
+	}
+
+	m.Nonce = nonce
+	return nil
+}


### PR DESCRIPTION
```
{
    "block_identifier": {
        "index": 1312343,
        "hash": "0x9774b69e80c152fefd18cd6afa0de9f3edffbc4cfcff01ea8639fc3eb4b7db9e"
    },
    "balances": [
        {
            "value": "156196229339915356",
            "currency": {
                "symbol": "AVAX",
                "decimals": 18
            }
        }
    ],
    "metadata": {
        "nonce": "0x7"
    }
}
```