### PR TITLE
remove `ContractCurrency` type

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ava-labs/avalanchego/api/info"
 	ethtypes "github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/interfaces"
+	"github.com/coinbase/rosetta-sdk-go/types"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
@@ -33,7 +34,7 @@ type Client interface {
 	TxPoolContent(context.Context) (*TxPoolContent, error)
 	GetNetworkName(context.Context) (string, error)
 	Peers(context.Context) ([]info.Peer, error)
-	GetContractCurrency(ethcommon.Address, bool) (*ContractCurrency, error)
+	GetContractCurrency(ethcommon.Address, bool) (*types.Currency, error)
 	CallContract(context.Context, interfaces.CallMsg, *big.Int) ([]byte, error)
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ava-labs/avalanchego/api/info"
 	ethtypes "github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/interfaces"
-	"github.com/coinbase/rosetta-sdk-go/types"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
@@ -34,7 +33,7 @@ type Client interface {
 	TxPoolContent(context.Context) (*TxPoolContent, error)
 	GetNetworkName(context.Context) (string, error)
 	Peers(context.Context) ([]info.Peer, error)
-	GetContractCurrency(ethcommon.Address, bool) (*types.Currency, error)
+	GetContractInfo(ethcommon.Address, bool) (string, uint8, error)
 	CallContract(context.Context, interfaces.CallMsg, *big.Int) ([]byte, error)
 }
 

--- a/client/contract.go
+++ b/client/contract.go
@@ -43,19 +43,18 @@ func (c *ContractClient) GetContractInfo(addr common.Address, erc20 bool) (strin
 		return "", 0, err
 	}
 
-	symbol, symbolErr := token.Symbol(nil)
-	decimals, decimalErr := token.Decimals(nil)
-
-	// Any of these indicate a failure to get complete information from contract
-	if symbolErr != nil || decimalErr != nil || symbol == "" || decimals == 0 {
+	// [symbol] is set to "" if [token.Symbol] errors.
+	symbol, _ := token.Symbol(nil)
+	if symbol == "" {
 		if erc20 {
 			symbol = UnknownERC20Symbol
-			decimals = UnknownERC20Decimals
 		} else {
 			symbol = UnknownERC721Symbol
-			decimals = UnknownERC721Decimals
 		}
 	}
+
+	// [decimals] is set to 0 if [token.Decimals] errors.
+	decimals, _ := token.Decimals(nil)
 
 	// Cache defaults for contract address to avoid unnecessary lookups
 	c.cache.Put(addr, &ContractInfo{

--- a/client/contract.go
+++ b/client/contract.go
@@ -3,6 +3,7 @@ package client
 import (
 	"github.com/ava-labs/avalanchego/cache"
 	"github.com/ava-labs/coreth/ethclient"
+	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -25,9 +26,9 @@ func NewContractClient(c ethclient.Client) *ContractClient {
 }
 
 // GetContractCurrency returns the currency for a specific address
-func (c *ContractClient) GetContractCurrency(addr common.Address, erc20 bool) (*ContractCurrency, error) {
+func (c *ContractClient) GetContractCurrency(addr common.Address, erc20 bool) (*types.Currency, error) {
 	if currency, cached := c.cache.Get(addr); cached {
-		return currency.(*ContractCurrency), nil
+		return currency.(*types.Currency), nil
 	}
 
 	token, err := NewContractInfoToken(addr, c.ethClient)
@@ -49,9 +50,12 @@ func (c *ContractClient) GetContractCurrency(addr common.Address, erc20 bool) (*
 		}
 	}
 
-	currency := &ContractCurrency{
+	currency := &types.Currency{
 		Symbol:   symbol,
 		Decimals: int32(decimals),
+		Metadata: map[string]interface{}{
+			ContractAddressMetadata: addr,
+		},
 	}
 
 	// Cache defaults for contract address to avoid unnecessary lookups

--- a/client/types.go
+++ b/client/types.go
@@ -13,8 +13,6 @@ const (
 
 	UnknownERC721Symbol   = "ERC721_UNKNOWN"
 	UnknownERC721Decimals = 0
-
-	ContractAddressMetadata = "contractAddress"
 )
 
 type Blockchain struct {

--- a/client/types.go
+++ b/client/types.go
@@ -13,12 +13,9 @@ const (
 
 	UnknownERC721Symbol   = "ERC721_UNKNOWN"
 	UnknownERC721Decimals = 0
-)
 
-type ContractCurrency struct {
-	Symbol   string `json:"symbol"`
-	Decimals int32  `json:"decimals"`
-}
+	ContractAddressMetadata = "contractAddress"
+)
 
 type Blockchain struct {
 	ID       string `json:"id"`

--- a/client/types.go
+++ b/client/types.go
@@ -8,11 +8,8 @@ import (
 )
 
 const (
-	UnknownERC20Symbol   = "ERC20_UNKNOWN"
-	UnknownERC20Decimals = 0
-
-	UnknownERC721Symbol   = "ERC721_UNKNOWN"
-	UnknownERC721Decimals = 0
+	UnknownERC20Symbol  = "ERC20_UNKNOWN"
+	UnknownERC721Symbol = "ERC721_UNKNOWN"
 )
 
 type Blockchain struct {

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -105,7 +105,7 @@ func (c *config) ValidateWhitelistOnlyValidErc20s(cli client.Client) error {
 		if err != nil {
 			return err
 		}
-		if decimals == client.UnknownERC20Decimals && symbol == client.UnknownERC20Symbol {
+		if decimals == 0 && symbol == client.UnknownERC20Symbol {
 			return errInvalidErc20Address
 		}
 	}

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -101,11 +101,11 @@ func (c *config) Validate() error {
 func (c *config) ValidateWhitelistOnlyValidErc20s(cli client.Client) error {
 	for _, token := range c.TokenWhiteList {
 		ethAddress := ethcommon.HexToAddress(token)
-		currency, err := cli.GetContractCurrency(ethAddress, true)
+		symbol, decimals, err := cli.GetContractInfo(ethAddress, true)
 		if err != nil {
 			return err
 		}
-		if currency.Decimals == client.UnknownERC20Decimals && currency.Symbol == client.UnknownERC20Symbol {
+		if decimals == client.UnknownERC20Decimals && symbol == client.UnknownERC20Symbol {
 			return errInvalidErc20Address
 		}
 	}

--- a/mapper/amount.go
+++ b/mapper/amount.go
@@ -11,9 +11,10 @@ func Amount(value *big.Int, currency *types.Currency) *types.Amount {
 	if value == nil {
 		return nil
 	}
+
 	return &types.Amount{
 		Value:    value.String(),
-		Currency: AvaxCurrency,
+		Currency: currency,
 	}
 }
 
@@ -23,29 +24,14 @@ func AvaxAmount(value *big.Int) *types.Amount {
 
 func Erc20Amount(
 	bytes []byte,
-	addr common.Address,
-	symbol string,
-	decimals int32,
-	sender bool) *types.Amount {
+	sender bool,
+	currency *types.Currency,
+) *types.Amount {
 	value := common.BytesToHash(bytes).Big()
 
 	if sender {
 		value = new(big.Int).Neg(value)
 	}
 
-	currency := Erc20Currency(symbol, decimals, addr.String())
-	return &types.Amount{
-		Value:    value.String(),
-		Currency: currency,
-	}
-}
-
-func Erc20Currency(symbol string, decimals int32, contractAddress string) *types.Currency {
-	return &types.Currency{
-		Symbol:   symbol,
-		Decimals: decimals,
-		Metadata: map[string]interface{}{
-			ContractAddressMetadata: contractAddress,
-		},
-	}
+	return Amount(value, currency)
 }

--- a/mapper/amount.go
+++ b/mapper/amount.go
@@ -24,8 +24,8 @@ func AvaxAmount(value *big.Int) *types.Amount {
 
 func Erc20Amount(
 	bytes []byte,
-	sender bool,
 	currency *types.Currency,
+	sender bool,
 ) *types.Amount {
 	value := common.BytesToHash(bytes).Big()
 

--- a/mapper/transaction.go
+++ b/mapper/transaction.go
@@ -441,8 +441,7 @@ func traceOps(trace []*clientTypes.FlatCall, startIndex int) []*types.Operation 
 	return ops
 }
 
-func erc20Ops(transferLog *ethtypes.Log, currency *clientTypes.ContractCurrency, opsLen int64) []*types.Operation {
-	contractAddress := transferLog.Address
+func erc20Ops(transferLog *ethtypes.Log, currency *types.Currency, opsLen int64) []*types.Operation {
 	fromAddress := common.BytesToAddress(transferLog.Topics[1].Bytes())
 	toAddress := common.BytesToAddress(transferLog.Topics[2].Bytes())
 
@@ -454,7 +453,7 @@ func erc20Ops(transferLog *ethtypes.Log, currency *clientTypes.ContractCurrency,
 			},
 			Status:  types.String(StatusSuccess),
 			Type:    OpErc20Mint,
-			Amount:  Erc20Amount(transferLog.Data, contractAddress, currency.Symbol, currency.Decimals, false),
+			Amount:  Erc20Amount(transferLog.Data, false, currency),
 			Account: Account(&toAddress),
 		}}
 	}
@@ -467,7 +466,7 @@ func erc20Ops(transferLog *ethtypes.Log, currency *clientTypes.ContractCurrency,
 			},
 			Status:  types.String(StatusSuccess),
 			Type:    OpErc20Burn,
-			Amount:  Erc20Amount(transferLog.Data, contractAddress, currency.Symbol, currency.Decimals, true),
+			Amount:  Erc20Amount(transferLog.Data, true, currency),
 			Account: Account(&fromAddress),
 		}}
 	}
@@ -479,7 +478,7 @@ func erc20Ops(transferLog *ethtypes.Log, currency *clientTypes.ContractCurrency,
 		},
 		Status:  types.String(StatusSuccess),
 		Type:    OpErc20Transfer,
-		Amount:  Erc20Amount(transferLog.Data, contractAddress, currency.Symbol, currency.Decimals, true),
+		Amount:  Erc20Amount(transferLog.Data, true, currency),
 		Account: Account(&fromAddress),
 	}, {
 		// Receive
@@ -488,7 +487,7 @@ func erc20Ops(transferLog *ethtypes.Log, currency *clientTypes.ContractCurrency,
 		},
 		Status:  types.String(StatusSuccess),
 		Type:    OpErc20Transfer,
-		Amount:  Erc20Amount(transferLog.Data, contractAddress, currency.Symbol, currency.Decimals, false),
+		Amount:  Erc20Amount(transferLog.Data, false, currency),
 		Account: Account(&toAddress),
 		RelatedOperations: []*types.OperationIdentifier{
 			{
@@ -502,8 +501,8 @@ func erc721Ops(transferLog *ethtypes.Log, opsLen int64) []*types.Operation {
 	fromAddress := common.BytesToAddress(transferLog.Topics[1].Bytes())
 	toAddress := common.BytesToAddress(transferLog.Topics[2].Bytes())
 	metadata := map[string]interface{}{
-		ContractAddressMetadata:  transferLog.Address.String(),
-		IndexTransferredMetadata: transferLog.Topics[3].String(),
+		clientTypes.ContractAddressMetadata: transferLog.Address.String(),
+		IndexTransferredMetadata:            transferLog.Topics[3].String(),
 	}
 
 	// Mint

--- a/mapper/transaction.go
+++ b/mapper/transaction.go
@@ -88,28 +88,28 @@ func Transaction(
 
 		switch len(log.Topics) {
 		case topicsInErc721Transfer:
-			currency, err := client.GetContractCurrency(log.Address, false)
+			symbol, _, err := client.GetContractInfo(log.Address, false)
 			if err != nil {
 				return nil, err
 			}
 
-			if currency.Symbol == clientTypes.UnknownERC721Symbol && !includeUnknownTokens {
+			if symbol == clientTypes.UnknownERC721Symbol && !includeUnknownTokens {
 				continue
 			}
 
 			erc721Ops := erc721Ops(log, int64(len(ops)))
 			ops = append(ops, erc721Ops...)
 		case topicsInErc20Transfer:
-			currency, err := client.GetContractCurrency(log.Address, true)
+			symbol, decimals, err := client.GetContractInfo(log.Address, true)
 			if err != nil {
 				return nil, err
 			}
 
-			if currency.Symbol == clientTypes.UnknownERC20Symbol && !includeUnknownTokens {
+			if symbol == clientTypes.UnknownERC20Symbol && !includeUnknownTokens {
 				continue
 			}
 
-			erc20Ops := erc20Ops(log, currency, int64(len(ops)))
+			erc20Ops := erc20Ops(log, ToCurrency(symbol, decimals, log.Address), int64(len(ops)))
 			ops = append(ops, erc20Ops...)
 		default:
 		}
@@ -501,8 +501,8 @@ func erc721Ops(transferLog *ethtypes.Log, opsLen int64) []*types.Operation {
 	fromAddress := common.BytesToAddress(transferLog.Topics[1].Bytes())
 	toAddress := common.BytesToAddress(transferLog.Topics[2].Bytes())
 	metadata := map[string]interface{}{
-		clientTypes.ContractAddressMetadata: transferLog.Address.String(),
-		IndexTransferredMetadata:            transferLog.Topics[3].String(),
+		ContractAddressMetadata:  transferLog.Address.String(),
+		IndexTransferredMetadata: transferLog.Topics[3].String(),
 	}
 
 	// Mint

--- a/mapper/transaction.go
+++ b/mapper/transaction.go
@@ -453,7 +453,7 @@ func erc20Ops(transferLog *ethtypes.Log, currency *types.Currency, opsLen int64)
 			},
 			Status:  types.String(StatusSuccess),
 			Type:    OpErc20Mint,
-			Amount:  Erc20Amount(transferLog.Data, false, currency),
+			Amount:  Erc20Amount(transferLog.Data, currency, false),
 			Account: Account(&toAddress),
 		}}
 	}
@@ -466,7 +466,7 @@ func erc20Ops(transferLog *ethtypes.Log, currency *types.Currency, opsLen int64)
 			},
 			Status:  types.String(StatusSuccess),
 			Type:    OpErc20Burn,
-			Amount:  Erc20Amount(transferLog.Data, true, currency),
+			Amount:  Erc20Amount(transferLog.Data, currency, true),
 			Account: Account(&fromAddress),
 		}}
 	}
@@ -478,7 +478,7 @@ func erc20Ops(transferLog *ethtypes.Log, currency *types.Currency, opsLen int64)
 		},
 		Status:  types.String(StatusSuccess),
 		Type:    OpErc20Transfer,
-		Amount:  Erc20Amount(transferLog.Data, true, currency),
+		Amount:  Erc20Amount(transferLog.Data, currency, true),
 		Account: Account(&fromAddress),
 	}, {
 		// Receive
@@ -487,7 +487,7 @@ func erc20Ops(transferLog *ethtypes.Log, currency *types.Currency, opsLen int64)
 		},
 		Status:  types.String(StatusSuccess),
 		Type:    OpErc20Transfer,
-		Amount:  Erc20Amount(transferLog.Data, false, currency),
+		Amount:  Erc20Amount(transferLog.Data, currency, false),
 		Account: Account(&toAddress),
 		RelatedOperations: []*types.OperationIdentifier{
 			{

--- a/mapper/transaction_test.go
+++ b/mapper/transaction_test.go
@@ -3,7 +3,7 @@ package mapper
 import (
 	"testing"
 
-	clientTypes "github.com/ava-labs/avalanche-rosetta/client"
+	"github.com/ava-labs/avalanche-rosetta/client"
 	ethtypes "github.com/ava-labs/coreth/core/types"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -36,11 +36,6 @@ func TestERC20Ops(t *testing.T) {
 			Data: ethcommon.FromHex("0x0000000000000000000000000000000000000000000009513ea9de0243800000"),
 		}
 
-		currency := clientTypes.ContractCurrency{
-			Symbol:   WAVAX.Symbol,
-			Decimals: WAVAX.Decimals,
-		}
-
 		assert.Equal(t, []*types.Operation{
 			{
 				OperationIdentifier: &types.OperationIdentifier{
@@ -75,7 +70,7 @@ func TestERC20Ops(t *testing.T) {
 					Currency: WAVAX,
 				},
 			},
-		}, erc20Ops(log, &currency, 1))
+		}, erc20Ops(log, WAVAX, 1))
 	})
 
 	t.Run("burn op", func(t *testing.T) {
@@ -87,11 +82,6 @@ func TestERC20Ops(t *testing.T) {
 				ethcommon.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
 			},
 			Data: ethcommon.FromHex("0x0000000000000000000000000000000000000000000009513ea9de0243800000"),
-		}
-
-		currency := clientTypes.ContractCurrency{
-			Symbol:   WAVAX.Symbol,
-			Decimals: WAVAX.Decimals,
 		}
 
 		assert.Equal(t, []*types.Operation{
@@ -109,7 +99,7 @@ func TestERC20Ops(t *testing.T) {
 					Currency: WAVAX,
 				},
 			},
-		}, erc20Ops(log, &currency, 1))
+		}, erc20Ops(log, WAVAX, 1))
 	})
 
 	t.Run("mint op", func(t *testing.T) {
@@ -121,11 +111,6 @@ func TestERC20Ops(t *testing.T) {
 				ethcommon.HexToHash("0x000000000000000000000000f1b77573a8525acfa116a785092d1ba90d96bf37"),
 			},
 			Data: ethcommon.FromHex("0x0000000000000000000000000000000000000000000009513ea9de0243800000"),
-		}
-
-		currency := clientTypes.ContractCurrency{
-			Symbol:   WAVAX.Symbol,
-			Decimals: WAVAX.Decimals,
 		}
 
 		assert.Equal(t, []*types.Operation{
@@ -143,7 +128,7 @@ func TestERC20Ops(t *testing.T) {
 					Currency: WAVAX,
 				},
 			},
-		}, erc20Ops(log, &currency, 1))
+		}, erc20Ops(log, WAVAX, 1))
 	})
 }
 
@@ -170,8 +155,8 @@ func TestERC721Ops(t *testing.T) {
 					Address: "0xf1B77573A8525aCfa116a785092d1Ba90D96BF37",
 				},
 				Metadata: map[string]interface{}{
-					ContractAddressMetadata:  "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
-					IndexTransferredMetadata: "0x0000000000000000000000000000000000000000000000000000000000000051",
+					client.ContractAddressMetadata: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+					IndexTransferredMetadata:       "0x0000000000000000000000000000000000000000000000000000000000000051",
 				},
 			},
 			{
@@ -189,8 +174,8 @@ func TestERC721Ops(t *testing.T) {
 					Address: "0x5d95ae932D42E53Bb9DA4DE65E9b7263A4fA8564",
 				},
 				Metadata: map[string]interface{}{
-					ContractAddressMetadata:  "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
-					IndexTransferredMetadata: "0x0000000000000000000000000000000000000000000000000000000000000051",
+					client.ContractAddressMetadata: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+					IndexTransferredMetadata:       "0x0000000000000000000000000000000000000000000000000000000000000051",
 				},
 			},
 		}, erc721Ops(log, 1))
@@ -218,8 +203,8 @@ func TestERC721Ops(t *testing.T) {
 					Address: "0xf1B77573A8525aCfa116a785092d1Ba90D96BF37",
 				},
 				Metadata: map[string]interface{}{
-					ContractAddressMetadata:  "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
-					IndexTransferredMetadata: "0x0000000000000000000000000000000000000000000000000000000000000051",
+					client.ContractAddressMetadata: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+					IndexTransferredMetadata:       "0x0000000000000000000000000000000000000000000000000000000000000051",
 				},
 			},
 		}, erc721Ops(log, 1))
@@ -247,8 +232,8 @@ func TestERC721Ops(t *testing.T) {
 					Address: "0xf1B77573A8525aCfa116a785092d1Ba90D96BF37",
 				},
 				Metadata: map[string]interface{}{
-					ContractAddressMetadata:  "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
-					IndexTransferredMetadata: "0x0000000000000000000000000000000000000000000000000000000000000051",
+					client.ContractAddressMetadata: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+					IndexTransferredMetadata:       "0x0000000000000000000000000000000000000000000000000000000000000051",
 				},
 			},
 		}, erc721Ops(log, 1))

--- a/mapper/transaction_test.go
+++ b/mapper/transaction_test.go
@@ -3,7 +3,6 @@ package mapper
 import (
 	"testing"
 
-	"github.com/ava-labs/avalanche-rosetta/client"
 	ethtypes "github.com/ava-labs/coreth/core/types"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -155,8 +154,8 @@ func TestERC721Ops(t *testing.T) {
 					Address: "0xf1B77573A8525aCfa116a785092d1Ba90D96BF37",
 				},
 				Metadata: map[string]interface{}{
-					client.ContractAddressMetadata: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
-					IndexTransferredMetadata:       "0x0000000000000000000000000000000000000000000000000000000000000051",
+					ContractAddressMetadata:  "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+					IndexTransferredMetadata: "0x0000000000000000000000000000000000000000000000000000000000000051",
 				},
 			},
 			{
@@ -174,8 +173,8 @@ func TestERC721Ops(t *testing.T) {
 					Address: "0x5d95ae932D42E53Bb9DA4DE65E9b7263A4fA8564",
 				},
 				Metadata: map[string]interface{}{
-					client.ContractAddressMetadata: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
-					IndexTransferredMetadata:       "0x0000000000000000000000000000000000000000000000000000000000000051",
+					ContractAddressMetadata:  "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+					IndexTransferredMetadata: "0x0000000000000000000000000000000000000000000000000000000000000051",
 				},
 			},
 		}, erc721Ops(log, 1))
@@ -203,8 +202,8 @@ func TestERC721Ops(t *testing.T) {
 					Address: "0xf1B77573A8525aCfa116a785092d1Ba90D96BF37",
 				},
 				Metadata: map[string]interface{}{
-					client.ContractAddressMetadata: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
-					IndexTransferredMetadata:       "0x0000000000000000000000000000000000000000000000000000000000000051",
+					ContractAddressMetadata:  "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+					IndexTransferredMetadata: "0x0000000000000000000000000000000000000000000000000000000000000051",
 				},
 			},
 		}, erc721Ops(log, 1))
@@ -232,8 +231,8 @@ func TestERC721Ops(t *testing.T) {
 					Address: "0xf1B77573A8525aCfa116a785092d1Ba90D96BF37",
 				},
 				Metadata: map[string]interface{}{
-					client.ContractAddressMetadata: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
-					IndexTransferredMetadata:       "0x0000000000000000000000000000000000000000000000000000000000000051",
+					ContractAddressMetadata:  "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+					IndexTransferredMetadata: "0x0000000000000000000000000000000000000000000000000000000000000051",
 				},
 			},
 		}, erc721Ops(log, 1))

--- a/mapper/types.go
+++ b/mapper/types.go
@@ -2,6 +2,7 @@ package mapper
 
 import (
 	"github.com/ava-labs/coreth/params"
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
@@ -13,6 +14,7 @@ const (
 	FujiChainID = 43113
 	FujiAssetID = "U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK"
 
+	ContractAddressMetadata  = "contractAddress"
 	IndexTransferredMetadata = "indexTransferred"
 
 	OpCall          = "CALL"
@@ -125,4 +127,14 @@ func CreateType(t string) bool {
 	}
 
 	return false
+}
+
+func ToCurrency(symbol string, decimals uint8, contractAddress common.Address) *types.Currency {
+	return &types.Currency{
+		Symbol:   symbol,
+		Decimals: int32(decimals),
+		Metadata: map[string]interface{}{
+			ContractAddressMetadata: contractAddress,
+		},
+	}
 }

--- a/mapper/types.go
+++ b/mapper/types.go
@@ -13,9 +13,7 @@ const (
 	FujiChainID = 43113
 	FujiAssetID = "U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK"
 
-	TokenTypeMetadata        = "tokenType"
 	IndexTransferredMetadata = "indexTransferred"
-	TokenSymbol              = "tokenSymbol"
 
 	OpCall          = "CALL"
 	OpFee           = "FEE"

--- a/mapper/types.go
+++ b/mapper/types.go
@@ -14,7 +14,6 @@ const (
 	FujiAssetID = "U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK"
 
 	TokenTypeMetadata        = "tokenType"
-	ContractAddressMetadata  = "contractAddress"
 	IndexTransferredMetadata = "indexTransferred"
 	TokenSymbol              = "tokenSymbol"
 

--- a/mocks/client/client.go
+++ b/mocks/client/client.go
@@ -16,8 +16,6 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 
-	rosetta_sdk_gotypes "github.com/coinbase/rosetta-sdk-go/types"
-
 	types "github.com/ava-labs/coreth/core/types"
 )
 
@@ -162,27 +160,32 @@ func (_m *Client) EstimateGas(_a0 context.Context, _a1 interfaces.CallMsg) (uint
 	return r0, r1
 }
 
-// GetContractCurrency provides a mock function with given fields: _a0, _a1
-func (_m *Client) GetContractCurrency(_a0 common.Address, _a1 bool) (*rosetta_sdk_gotypes.Currency, error) {
+// GetContractInfo provides a mock function with given fields: _a0, _a1
+func (_m *Client) GetContractInfo(_a0 common.Address, _a1 bool) (string, uint8, error) {
 	ret := _m.Called(_a0, _a1)
 
-	var r0 *rosetta_sdk_gotypes.Currency
-	if rf, ok := ret.Get(0).(func(common.Address, bool) *rosetta_sdk_gotypes.Currency); ok {
+	var r0 string
+	if rf, ok := ret.Get(0).(func(common.Address, bool) string); ok {
 		r0 = rf(_a0, _a1)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*rosetta_sdk_gotypes.Currency)
-		}
+		r0 = ret.Get(0).(string)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(common.Address, bool) error); ok {
+	var r1 uint8
+	if rf, ok := ret.Get(1).(func(common.Address, bool) uint8); ok {
 		r1 = rf(_a0, _a1)
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(uint8)
 	}
 
-	return r0, r1
+	var r2 error
+	if rf, ok := ret.Get(2).(func(common.Address, bool) error); ok {
+		r2 = rf(_a0, _a1)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // GetNetworkName provides a mock function with given fields: _a0

--- a/mocks/client/client.go
+++ b/mocks/client/client.go
@@ -10,10 +10,13 @@ import (
 
 	context "context"
 
+	info "github.com/ava-labs/avalanchego/api/info"
+
 	interfaces "github.com/ava-labs/coreth/interfaces"
 
 	mock "github.com/stretchr/testify/mock"
-	"github.com/ava-labs/avalanchego/api/info"
+
+	rosetta_sdk_gotypes "github.com/coinbase/rosetta-sdk-go/types"
 
 	types "github.com/ava-labs/coreth/core/types"
 )
@@ -160,15 +163,15 @@ func (_m *Client) EstimateGas(_a0 context.Context, _a1 interfaces.CallMsg) (uint
 }
 
 // GetContractCurrency provides a mock function with given fields: _a0, _a1
-func (_m *Client) GetContractCurrency(_a0 common.Address, _a1 bool) (*client.ContractCurrency, error) {
+func (_m *Client) GetContractCurrency(_a0 common.Address, _a1 bool) (*rosetta_sdk_gotypes.Currency, error) {
 	ret := _m.Called(_a0, _a1)
 
-	var r0 *client.ContractCurrency
-	if rf, ok := ret.Get(0).(func(common.Address, bool) *client.ContractCurrency); ok {
+	var r0 *rosetta_sdk_gotypes.Currency
+	if rf, ok := ret.Get(0).(func(common.Address, bool) *rosetta_sdk_gotypes.Currency); ok {
 		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*client.ContractCurrency)
+			r0 = ret.Get(0).(*rosetta_sdk_gotypes.Currency)
 		}
 	}
 

--- a/service/service_account.go
+++ b/service/service_account.go
@@ -76,7 +76,7 @@ func (s AccountService) AccountBalance(
 	}
 
 	for _, currency := range req.Currencies {
-		value, ok := currency.Metadata[client.ContractAddressMetadata]
+		value, ok := currency.Metadata[mapper.ContractAddressMetadata]
 		if !ok {
 			if utils.Equal(currency, mapper.AvaxCurrency) {
 				balances = append(balances, mapper.AvaxAmount(avaxBalance))

--- a/service/service_account.go
+++ b/service/service_account.go
@@ -102,7 +102,7 @@ func (s AccountService) AccountBalance(
 			return nil, wrapError(errInternalError, err)
 		}
 
-		amount := mapper.Erc20Amount(response, contractAddress, currency.Symbol, currency.Decimals, false)
+		amount := mapper.Erc20Amount(response, false, currency)
 
 		balances = append(balances, amount)
 	}

--- a/service/service_account.go
+++ b/service/service_account.go
@@ -102,7 +102,7 @@ func (s AccountService) AccountBalance(
 			return nil, wrapError(errInternalError, err)
 		}
 
-		amount := mapper.Erc20Amount(response, false, currency)
+		amount := mapper.Erc20Amount(response, currency, false)
 
 		balances = append(balances, amount)
 	}

--- a/service/service_account.go
+++ b/service/service_account.go
@@ -76,7 +76,7 @@ func (s AccountService) AccountBalance(
 	}
 
 	for _, currency := range req.Currencies {
-		value, ok := currency.Metadata[mapper.ContractAddressMetadata]
+		value, ok := currency.Metadata[client.ContractAddressMetadata]
 		if !ok {
 			if utils.Equal(currency, mapper.AvaxCurrency) {
 				balances = append(balances, mapper.AvaxAmount(avaxBalance))

--- a/service/service_construction.go
+++ b/service/service_construction.go
@@ -440,7 +440,7 @@ func (s ConstructionService) ConstructionPayloads(
 		transferData = []byte{}
 		sendToAddress = ethcommon.HexToAddress(checkTo)
 	} else {
-		contract, ok := fromCurrency.Metadata[client.ContractAddressMetadata].(string)
+		contract, ok := fromCurrency.Metadata[mapper.ContractAddressMetadata].(string)
 		if !ok {
 			return nil, wrapError(errInvalidInput,
 				fmt.Errorf("%s currency doesn't have a contract address in metadata", fromCurrency.Symbol))
@@ -642,15 +642,15 @@ func (s ConstructionService) CreateOperationDescription(
 	if types.Hash(firstCurrency) == types.Hash(mapper.AvaxCurrency) {
 		return s.createOperationDescriptionNative(), nil
 	}
-	firstContract, firstOk := firstCurrency.Metadata[client.ContractAddressMetadata].(string)
-	_, secondOk := secondCurrency.Metadata[client.ContractAddressMetadata].(string)
+	_, firstOk := firstCurrency.Metadata[mapper.ContractAddressMetadata].(string)
+	_, secondOk := secondCurrency.Metadata[mapper.ContractAddressMetadata].(string)
 
 	// Not Native Avax, we require contractInfo in metadata
 	if !firstOk || !secondOk {
 		return nil, fmt.Errorf("non-native currency must have contractAddress in metadata")
 	}
 
-	return s.createOperationDescriptionERC20(firstContract, firstCurrency), nil
+	return s.createOperationDescriptionERC20(firstCurrency), nil
 }
 
 func (s ConstructionService) createOperationDescriptionNative() []*parser.OperationDescription {
@@ -684,9 +684,7 @@ func (s ConstructionService) createOperationDescriptionNative() []*parser.Operat
 	return descriptions
 }
 
-func (s ConstructionService) createOperationDescriptionERC20(
-	contractAddress string, currency *types.Currency,
-) []*parser.OperationDescription {
+func (s ConstructionService) createOperationDescriptionERC20(currency *types.Currency) []*parser.OperationDescription {
 	var descriptions []*parser.OperationDescription
 
 	send := parser.OperationDescription{
@@ -738,7 +736,7 @@ func (s ConstructionService) getNativeTransferGasLimit(ctx context.Context, toAd
 
 func (s ConstructionService) getErc20TransferGasLimit(ctx context.Context, toAddress string,
 	fromAddress string, value *big.Int, currency *types.Currency) (uint64, error) {
-	contract, ok := currency.Metadata[client.ContractAddressMetadata]
+	contract, ok := currency.Metadata[mapper.ContractAddressMetadata]
 	if len(toAddress) == 0 || value == nil || !ok {
 		return erc20TransferGasLimit, nil
 	}

--- a/service/service_construction.go
+++ b/service/service_construction.go
@@ -440,7 +440,7 @@ func (s ConstructionService) ConstructionPayloads(
 		transferData = []byte{}
 		sendToAddress = ethcommon.HexToAddress(checkTo)
 	} else {
-		contract, ok := fromCurrency.Metadata[mapper.ContractAddressMetadata].(string)
+		contract, ok := fromCurrency.Metadata[client.ContractAddressMetadata].(string)
 		if !ok {
 			return nil, wrapError(errInvalidInput,
 				fmt.Errorf("%s currency doesn't have a contract address in metadata", fromCurrency.Symbol))
@@ -642,8 +642,8 @@ func (s ConstructionService) CreateOperationDescription(
 	if types.Hash(firstCurrency) == types.Hash(mapper.AvaxCurrency) {
 		return s.createOperationDescriptionNative(), nil
 	}
-	firstContract, firstOk := firstCurrency.Metadata[mapper.ContractAddressMetadata].(string)
-	_, secondOk := secondCurrency.Metadata[mapper.ContractAddressMetadata].(string)
+	firstContract, firstOk := firstCurrency.Metadata[client.ContractAddressMetadata].(string)
+	_, secondOk := secondCurrency.Metadata[client.ContractAddressMetadata].(string)
 
 	// Not Native Avax, we require contractInfo in metadata
 	if !firstOk || !secondOk {
@@ -739,7 +739,7 @@ func (s ConstructionService) getNativeTransferGasLimit(ctx context.Context, toAd
 
 func (s ConstructionService) getErc20TransferGasLimit(ctx context.Context, toAddress string,
 	fromAddress string, value *big.Int, currency *types.Currency) (uint64, error) {
-	contract, ok := currency.Metadata[mapper.ContractAddressMetadata]
+	contract, ok := currency.Metadata[client.ContractAddressMetadata]
 	if len(toAddress) == 0 || value == nil || !ok {
 		return erc20TransferGasLimit, nil
 	}

--- a/service/service_construction.go
+++ b/service/service_construction.go
@@ -685,10 +685,9 @@ func (s ConstructionService) createOperationDescriptionNative() []*parser.Operat
 }
 
 func (s ConstructionService) createOperationDescriptionERC20(
-	contractAddress string, currencyInfo *types.Currency,
+	contractAddress string, currency *types.Currency,
 ) []*parser.OperationDescription {
 	var descriptions []*parser.OperationDescription
-	currency := mapper.Erc20Currency(currencyInfo.Symbol, currencyInfo.Decimals, contractAddress)
 
 	send := parser.OperationDescription{
 		Type: mapper.OpErc20Transfer,

--- a/service/service_construction_test.go
+++ b/service/service_construction_test.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 	"testing"
 
-	clientTypes "github.com/ava-labs/avalanche-rosetta/client"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 	mocks "github.com/ava-labs/avalanche-rosetta/mocks/client"
 	"github.com/ava-labs/coreth/interfaces"
@@ -776,7 +775,7 @@ func TestPreprocessMetadata(t *testing.T) {
 			config: &Config{Mode: ModeOnline, TokenWhiteList: tokenList},
 			client: client,
 		}
-		currency := &clientTypes.ContractCurrency{Symbol: defaultSymbol, Decimals: defaultDecimals}
+		currency := &types.Currency{Symbol: defaultSymbol, Decimals: defaultDecimals}
 		client.On(
 			"ContractInfo",
 			common.HexToAddress(defaultContractAddress),


### PR DESCRIPTION
We maintain an invariant that `contractAddress` is always populated in ERC-20 metadata making this type unnecessary.

ERC-721s don't use currencies since they are transferred by index.