### PR TITLE
/construction/derive support for p-chain and c-chain bech32 addresses

### DIFF
--- a/mapper/helper.go
+++ b/mapper/helper.go
@@ -1,8 +1,14 @@
 package mapper
 
 import (
+	"errors"
 	"strings"
+
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/coinbase/rosetta-sdk-go/types"
 )
+
+var errUnrecognizedNetwork = errors.New("can't recognize network")
 
 // EqualFoldContains checks if the array contains the string regardless of casing
 func EqualFoldContains(arr []string, str string) bool {
@@ -12,4 +18,19 @@ func EqualFoldContains(arr []string, str string) bool {
 		}
 	}
 	return false
+}
+
+// GetHRP fetches hrp for address formatting.
+func GetHRP(networkIdentifier *types.NetworkIdentifier) (string, error) {
+	var hrp string
+	switch networkIdentifier.Network {
+	case FujiNetwork:
+		hrp = constants.GetHRP(constants.FujiID)
+	case MainnetNetwork:
+		hrp = constants.GetHRP(constants.MainnetID)
+	default:
+		return "", errUnrecognizedNetwork
+	}
+
+	return hrp, nil
 }

--- a/mapper/types.go
+++ b/mapper/types.go
@@ -45,6 +45,9 @@ const (
 
 	StatusSuccess = "SUCCESS"
 	StatusFailure = "FAILURE"
+
+	MetaAddressFormat   = "address_format"
+	AddressFormatBech32 = "bech32"
 )
 
 var (

--- a/service/backend/cchainatomictx/backend.go
+++ b/service/backend/cchainatomictx/backend.go
@@ -1,6 +1,10 @@
 package cchainatomictx
 
 import (
+	"github.com/ava-labs/avalanchego/utils/crypto"
+	"github.com/coinbase/rosetta-sdk-go/types"
+
+	"github.com/ava-labs/avalanche-rosetta/mapper"
 	"github.com/ava-labs/avalanche-rosetta/service"
 )
 
@@ -9,12 +13,39 @@ var (
 	_ service.AccountBackend      = &Backend{}
 )
 
-type Backend struct{}
+type Backend struct {
+	fac *crypto.FactorySECP256K1R
+}
 
 func NewBackend() (*Backend, error) {
-	return &Backend{}, nil
+	return &Backend{
+		fac: &crypto.FactorySECP256K1R{},
+	}, nil
 }
 
 func (b *Backend) ShouldHandleRequest(req interface{}) bool {
+	switch r := req.(type) {
+	case *types.AccountBalanceRequest:
+		return false
+	case *types.AccountCoinsRequest:
+		return false
+	case *types.ConstructionDeriveRequest:
+		return r.Metadata[mapper.MetaAddressFormat] == mapper.AddressFormatBech32
+	case *types.ConstructionMetadataRequest:
+		return false
+	case *types.ConstructionPreprocessRequest:
+		return false
+	case *types.ConstructionPayloadsRequest:
+		return false
+	case *types.ConstructionParseRequest:
+		return false
+	case *types.ConstructionCombineRequest:
+		return false
+	case *types.ConstructionHashRequest:
+		return false
+	case *types.ConstructionSubmitRequest:
+		return false
+	}
+
 	return false
 }

--- a/service/backend/cchainatomictx/backend_test.go
+++ b/service/backend/cchainatomictx/backend_test.go
@@ -1,0 +1,39 @@
+package cchainatomictx
+
+import (
+	"testing"
+
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ava-labs/avalanche-rosetta/mapper"
+	"github.com/ava-labs/avalanche-rosetta/service"
+)
+
+func TestShouldHandleRequest(t *testing.T) {
+	networkIdentifier := &types.NetworkIdentifier{
+		Blockchain: service.BlockchainName,
+		Network:    mapper.FujiNetwork,
+	}
+
+	backend, _ := NewBackend()
+
+	t.Run("should handle c-chain bech32 request", func(t *testing.T) {
+		assert.True(t, backend.ShouldHandleRequest(
+			&types.ConstructionDeriveRequest{
+				NetworkIdentifier: networkIdentifier,
+				Metadata: map[string]interface{}{
+					mapper.MetaAddressFormat: mapper.AddressFormatBech32,
+				},
+			},
+		))
+	})
+
+	t.Run("should not handle regular c-chain request", func(t *testing.T) {
+		assert.False(t, backend.ShouldHandleRequest(
+			&types.ConstructionDeriveRequest{
+				NetworkIdentifier: networkIdentifier,
+			},
+		))
+	})
+}

--- a/service/backend/cchainatomictx/construction.go
+++ b/service/backend/cchainatomictx/construction.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 
+	"github.com/ava-labs/avalanche-rosetta/mapper"
 	"github.com/ava-labs/avalanche-rosetta/service"
+	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
 )
 
 func (b *Backend) ConstructionDerive(ctx context.Context, req *types.ConstructionDeriveRequest) (*types.ConstructionDeriveResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+	return common.DeriveBech32Address(b.fac, mapper.CChainNetworkIdentifier, req)
 }
 
 func (b *Backend) ConstructionPreprocess(ctx context.Context, req *types.ConstructionPreprocessRequest) (*types.ConstructionPreprocessResponse, *types.Error) {

--- a/service/backend/cchainatomictx/construction_test.go
+++ b/service/backend/cchainatomictx/construction_test.go
@@ -1,0 +1,44 @@
+package cchainatomictx
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ava-labs/avalanche-rosetta/mapper"
+	"github.com/ava-labs/avalanche-rosetta/service"
+)
+
+var networkIdentifier = &types.NetworkIdentifier{
+	Blockchain: service.BlockchainName,
+	Network:    mapper.FujiNetwork,
+}
+
+func TestConstructionDerive(t *testing.T) {
+	backend, _ := NewBackend()
+
+	t.Run("c-chain address", func(t *testing.T) {
+		src := "02e0d4392cfa224d4be19db416b3cf62e90fb2b7015e7b62a95c8cb490514943f6"
+		b, _ := hex.DecodeString(src)
+
+		resp, err := backend.ConstructionDerive(
+			context.Background(),
+			&types.ConstructionDeriveRequest{
+				NetworkIdentifier: networkIdentifier,
+				PublicKey: &types.PublicKey{
+					Bytes:     b,
+					CurveType: types.Secp256k1,
+				},
+			},
+		)
+		assert.Nil(t, err)
+		assert.Equal(
+			t,
+			"C-fuji15f9g0h5xkr5cp47n6u3qxj6yjtzzzrdr23a3tl",
+			resp.AccountIdentifier.Address,
+		)
+	})
+}

--- a/service/backend/common/construction.go
+++ b/service/backend/common/construction.go
@@ -1,0 +1,33 @@
+package common
+
+import (
+	"github.com/ava-labs/avalanchego/utils/crypto"
+	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/coinbase/rosetta-sdk-go/types"
+
+	"github.com/ava-labs/avalanche-rosetta/mapper"
+	"github.com/ava-labs/avalanche-rosetta/service"
+)
+
+func DeriveBech32Address(fac *crypto.FactorySECP256K1R, chainIDAlias string, req *types.ConstructionDeriveRequest) (*types.ConstructionDeriveResponse, *types.Error) {
+	pub, err := fac.ToPublicKey(req.PublicKey.Bytes)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	hrp, getErr := mapper.GetHRP(req.NetworkIdentifier)
+	if getErr != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	addr, err := address.Format(chainIDAlias, hrp, pub.Address().Bytes())
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	return &types.ConstructionDeriveResponse{
+		AccountIdentifier: &types.AccountIdentifier{
+			Address: addr,
+		},
+	}, nil
+}

--- a/service/backend/pchain/backend.go
+++ b/service/backend/pchain/backend.go
@@ -1,6 +1,7 @@
 package pchain
 
 import (
+	"github.com/ava-labs/avalanchego/utils/crypto"
 	"github.com/coinbase/rosetta-sdk-go/types"
 
 	pmapper "github.com/ava-labs/avalanche-rosetta/mapper/pchain"
@@ -15,11 +16,15 @@ var (
 )
 
 type Backend struct {
+	fac               *crypto.FactorySECP256K1R
 	networkIdentifier *types.NetworkIdentifier
 }
 
 func NewBackend(networkIdentifier *types.NetworkIdentifier) (*Backend, error) {
-	return &Backend{networkIdentifier: networkIdentifier}, nil
+	return &Backend{
+		fac:               &crypto.FactorySECP256K1R{},
+		networkIdentifier: networkIdentifier,
+	}, nil
 }
 
 func (b *Backend) ShouldHandleRequest(req interface{}) bool {

--- a/service/backend/pchain/backend_test.go
+++ b/service/backend/pchain/backend_test.go
@@ -1,0 +1,62 @@
+package pchain
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ava-labs/avalanche-rosetta/mapper"
+	"github.com/ava-labs/avalanche-rosetta/service"
+)
+
+func TestShouldHandleRequest(t *testing.T) {
+	pChainNetworkIdentifier := &types.NetworkIdentifier{
+		Blockchain: service.BlockchainName,
+		Network:    mapper.FujiNetwork,
+		SubNetworkIdentifier: &types.SubNetworkIdentifier{
+			Network: mapper.PChainNetworkIdentifier,
+		},
+	}
+
+	cChainNetworkIdentifier := &types.NetworkIdentifier{
+		Blockchain: service.BlockchainName,
+		Network:    mapper.FujiNetwork,
+	}
+
+	backend, _ := NewBackend(pChainNetworkIdentifier)
+
+	testData := []struct {
+		name              string
+		networkIdentifier *types.NetworkIdentifier
+		expected          bool
+	}{
+		{"p-chain", pChainNetworkIdentifier, true},
+		{"c-chain", cChainNetworkIdentifier, false},
+	}
+
+	for _, tc := range testData {
+		t.Run(fmt.Sprintf("should handle request for %s should return %t", tc.name, tc.expected), func(t *testing.T) {
+			requests := []interface{}{
+				&types.ConstructionDeriveRequest{NetworkIdentifier: tc.networkIdentifier},
+				&types.ConstructionPreprocessRequest{NetworkIdentifier: tc.networkIdentifier},
+				&types.ConstructionMetadataRequest{NetworkIdentifier: tc.networkIdentifier},
+				&types.ConstructionPayloadsRequest{NetworkIdentifier: tc.networkIdentifier},
+				&types.ConstructionCombineRequest{NetworkIdentifier: tc.networkIdentifier},
+				&types.ConstructionHashRequest{NetworkIdentifier: tc.networkIdentifier},
+				&types.ConstructionSubmitRequest{NetworkIdentifier: tc.networkIdentifier},
+				&types.AccountBalanceRequest{NetworkIdentifier: tc.networkIdentifier},
+				&types.AccountCoinsRequest{NetworkIdentifier: tc.networkIdentifier},
+				&types.AccountBalanceRequest{NetworkIdentifier: tc.networkIdentifier},
+				&types.AccountCoinsRequest{NetworkIdentifier: tc.networkIdentifier},
+				&types.BlockRequest{NetworkIdentifier: tc.networkIdentifier},
+				&types.BlockTransactionRequest{NetworkIdentifier: tc.networkIdentifier},
+				&types.NetworkRequest{NetworkIdentifier: tc.networkIdentifier},
+			}
+			for _, r := range requests {
+				assert.Equal(t, tc.expected, backend.ShouldHandleRequest(r))
+			}
+		})
+	}
+}

--- a/service/backend/pchain/construction.go
+++ b/service/backend/pchain/construction.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 
+	"github.com/ava-labs/avalanche-rosetta/mapper"
 	"github.com/ava-labs/avalanche-rosetta/service"
+	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
 )
 
 func (b *Backend) ConstructionDerive(ctx context.Context, req *types.ConstructionDeriveRequest) (*types.ConstructionDeriveResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+	return common.DeriveBech32Address(b.fac, mapper.PChainNetworkIdentifier, req)
 }
 
 func (b *Backend) ConstructionPreprocess(ctx context.Context, req *types.ConstructionPreprocessRequest) (*types.ConstructionPreprocessResponse, *types.Error) {

--- a/service/backend/pchain/construction_test.go
+++ b/service/backend/pchain/construction_test.go
@@ -1,0 +1,52 @@
+package pchain
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ava-labs/avalanche-rosetta/mapper"
+	"github.com/ava-labs/avalanche-rosetta/service"
+)
+
+var pChainNetworkIdentifier = &types.NetworkIdentifier{
+	Blockchain: service.BlockchainName,
+	Network:    mapper.FujiNetwork,
+	SubNetworkIdentifier: &types.SubNetworkIdentifier{
+		Network: mapper.PChainNetworkIdentifier,
+	},
+}
+
+func TestConstructionDerive(t *testing.T) {
+	backend, _ := NewBackend(pChainNetworkIdentifier)
+
+	t.Run("p-chain address", func(t *testing.T) {
+		src := "02e0d4392cfa224d4be19db416b3cf62e90fb2b7015e7b62a95c8cb490514943f6"
+		b, _ := hex.DecodeString(src)
+
+		resp, err := backend.ConstructionDerive(
+			context.Background(),
+			&types.ConstructionDeriveRequest{
+				NetworkIdentifier: &types.NetworkIdentifier{
+					Network: mapper.FujiNetwork,
+					SubNetworkIdentifier: &types.SubNetworkIdentifier{
+						Network: mapper.PChainNetworkIdentifier,
+					},
+				},
+				PublicKey: &types.PublicKey{
+					Bytes:     b,
+					CurveType: types.Secp256k1,
+				},
+			},
+		)
+		assert.Nil(t, err)
+		assert.Equal(
+			t,
+			"P-fuji15f9g0h5xkr5cp47n6u3qxj6yjtzzzrdr23a3tl",
+			resp.AccountIdentifier.Address,
+		)
+	})
+}


### PR DESCRIPTION
`/construction/derive` endpoint implementation for Bech32 addresses used for P-chain transactions (both P-chain and C-chain addresses).

