### PR TITLE
P-chain parse combine hash submit

### DIFF
--- a/service/backend/pchain/construction.go
+++ b/service/backend/pchain/construction.go
@@ -2,15 +2,25 @@ package pchain
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm"
 	"github.com/coinbase/rosetta-sdk-go/types"
 
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 	pmapper "github.com/ava-labs/avalanche-rosetta/mapper/pchain"
 	"github.com/ava-labs/avalanche-rosetta/service"
 	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
+)
+
+var (
+	errUnknownTxType = errors.New("unknown tx type")
+	errUndecodableTx = errors.New("undecodable transaction")
+	errNoTxGiven     = errors.New("no transaction was given")
 )
 
 func (b *Backend) ConstructionDerive(ctx context.Context, req *types.ConstructionDeriveRequest) (*types.ConstructionDeriveResponse, *types.Error) {
@@ -179,11 +189,93 @@ func (b *Backend) ConstructionPayloads(ctx context.Context, req *types.Construct
 }
 
 func (b *Backend) ConstructionParse(ctx context.Context, req *types.ConstructionParseRequest) (*types.ConstructionParseResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+	rosettaTx, err := b.parsePayloadTxFromString(req.Transaction)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	hrp, err := mapper.GetHRP(req.NetworkIdentifier)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, "incorrect network identifier")
+	}
+
+	chainIDs := map[string]string{}
+	if rosettaTx.DestinationChainID != nil {
+		chainIDs[rosettaTx.DestinationChainID.String()] = rosettaTx.DestinationChain
+	}
+
+	txParser := pTxParser{
+		hrp:      hrp,
+		chainIDs: chainIDs,
+	}
+
+	return common.Parse(txParser, rosettaTx, req.Signed)
 }
 
 func (b *Backend) ConstructionCombine(ctx context.Context, req *types.ConstructionCombineRequest) (*types.ConstructionCombineResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+	rosettaTx, err := b.parsePayloadTxFromString(req.UnsignedTransaction)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	return common.Combine(b, rosettaTx, req.Signatures)
+}
+
+func (b *Backend) CombineTx(tx common.AvaxTx, signatures []*types.Signature) (common.AvaxTx, *types.Error) {
+	pTx, ok := tx.(*pTx)
+	if !ok {
+		return nil, service.WrapError(service.ErrInvalidInput, "invalid transaction")
+	}
+
+	ins, err := getTxInputs(pTx.Tx.UnsignedTx)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	creds, err := common.BuildCredentialList(ins, signatures)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	unsignedBytes, err := pTx.Marshal()
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	pTx.Tx.Creds = creds
+
+	signedBytes, err := pTx.Marshal()
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	pTx.Tx.Initialize(unsignedBytes, signedBytes)
+
+	return pTx, nil
+}
+
+// getTxInputs fetches tx inputs based on the tx type.
+func getTxInputs(
+	unsignedTx platformvm.UnsignedTx,
+) ([]*avax.TransferableInput, error) {
+	switch utx := unsignedTx.(type) {
+	case *platformvm.UnsignedAddValidatorTx:
+		return utx.Ins, nil
+	case *platformvm.UnsignedAddSubnetValidatorTx:
+		return utx.Ins, nil
+	case *platformvm.UnsignedAddDelegatorTx:
+		return utx.Ins, nil
+	case *platformvm.UnsignedCreateChainTx:
+		return utx.Ins, nil
+	case *platformvm.UnsignedCreateSubnetTx:
+		return utx.Ins, nil
+	case *platformvm.UnsignedImportTx:
+		return utx.ImportedInputs, nil
+	case *platformvm.UnsignedExportTx:
+		return utx.Ins, nil
+	default:
+		return nil, errUnknownTxType
+	}
 }
 
 func (b *Backend) ConstructionHash(ctx context.Context, req *types.ConstructionHashRequest) (*types.TransactionIdentifierResponse, *types.Error) {
@@ -192,4 +284,25 @@ func (b *Backend) ConstructionHash(ctx context.Context, req *types.ConstructionH
 
 func (b *Backend) ConstructionSubmit(ctx context.Context, req *types.ConstructionSubmitRequest) (*types.TransactionIdentifierResponse, *types.Error) {
 	return nil, service.ErrNotImplemented
+}
+
+func (b *Backend) parsePayloadTxFromString(transaction string) (*common.RosettaTx, error) {
+	// Unmarshal input transaction
+	payloadsTx := &common.RosettaTx{
+		Tx: &pTx{
+			Codec:        b.codec,
+			CodecVersion: b.codecVersion,
+		},
+	}
+
+	err := json.Unmarshal([]byte(transaction), payloadsTx)
+	if err != nil {
+		return nil, errUndecodableTx
+	}
+
+	if payloadsTx.Tx == nil {
+		return nil, errNoTxGiven
+	}
+
+	return payloadsTx, nil
 }

--- a/service/backend/pchain/construction.go
+++ b/service/backend/pchain/construction.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -278,12 +279,33 @@ func getTxInputs(
 	}
 }
 
-func (b *Backend) ConstructionHash(ctx context.Context, req *types.ConstructionHashRequest) (*types.TransactionIdentifierResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+func (b *Backend) ConstructionHash(
+	ctx context.Context,
+	req *types.ConstructionHashRequest,
+) (*types.TransactionIdentifierResponse, *types.Error) {
+	rosettaTx, err := b.parsePayloadTxFromString(req.SignedTransaction)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	return common.HashTx(rosettaTx)
 }
 
-func (b *Backend) ConstructionSubmit(ctx context.Context, req *types.ConstructionSubmitRequest) (*types.TransactionIdentifierResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+func (b *Backend) ConstructionSubmit(
+	ctx context.Context,
+	req *types.ConstructionSubmitRequest,
+) (*types.TransactionIdentifierResponse, *types.Error) {
+	rosettaTx, err := b.parsePayloadTxFromString(req.SignedTransaction)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	return common.SubmitTx(ctx, b, rosettaTx)
+}
+
+// Defining IssueTx here without rpc.Options... to be able to use it with common.SubmitTx
+func (b *Backend) IssueTx(ctx context.Context, txByte []byte) (ids.ID, error) {
+	return b.pClient.IssueTx(ctx, txByte)
 }
 
 func (b *Backend) parsePayloadTxFromString(transaction string) (*common.RosettaTx, error) {

--- a/service/backend/pchain/construction_test.go
+++ b/service/backend/pchain/construction_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/formatting"
 	ajson "github.com/ava-labs/avalanchego/utils/json"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/stretchr/testify/assert"
@@ -159,6 +160,7 @@ func TestExportTxConstruction(t *testing.T) {
 
 	signedExportTx := "0x0000000000120000000500000000000000000000000000000000000000000000000000000000000000000000000000000001f52a5a6dd8f1b3fe05204bdab4f6bcb5a7059f88d0443c636f6c158f838dd1a8000000003d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa00000005000000003b9aca000000000100000000000000007fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d5000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa00000007000000003b8b87c0000000000000000000000001000000015445cd01d75b4a06b6b41939193c0b1c5544490d0000000100000009000000017403e32bb967e71902a988b7da635b4bca2475eedbfd23176610a88162f3a92f20b61f2185825b04b7f8ee8c76427c8dc80eb6091f9e594ef259a59856e5401b0137dc0dc4"
 	signedExportTxSignature, _ := hex.DecodeString("7403e32bb967e71902a988b7da635b4bca2475eedbfd23176610a88162f3a92f20b61f2185825b04b7f8ee8c76427c8dc80eb6091f9e594ef259a59856e5401b01")
+	signedExportTxHash := "bG7jzw16x495XSFdhEavHWR836Ya5teoB1YxRC1inN3HEtqbs"
 
 	wrappedTxFormat := `{"tx":"%s","signers":%s,"destination_chain":"%s","destination_chain_id":"%s"}`
 	wrappedUnsignedExportTx := fmt.Sprintf(wrappedTxFormat, unsignedExportTx, exportSigners, "C", cChainID.String())
@@ -274,9 +276,33 @@ func TestExportTxConstruction(t *testing.T) {
 		clientMock.AssertExpectations(t)
 	})
 
-	t.Run("hash endpoint", func(t *testing.T) {})
+	t.Run("hash endpoint", func(t *testing.T) {
+		resp, err := backend.ConstructionHash(ctx, &types.ConstructionHashRequest{
+			NetworkIdentifier: pChainNetworkIdentifier,
+			SignedTransaction: wrappedSignedExportTx,
+		})
+		assert.Nil(t, err)
+		assert.Equal(t, signedExportTxHash, resp.TransactionIdentifier.Hash)
 
-	t.Run("submit endpoint", func(t *testing.T) {})
+		clientMock.AssertExpectations(t)
+	})
+
+	t.Run("submit endpoint", func(t *testing.T) {
+		signedTxBytes, _ := formatting.Decode(formatting.Hex, signedExportTx)
+		txID, _ := ids.FromString(signedExportTxHash)
+
+		clientMock.On("IssueTx", ctx, signedTxBytes).Return(txID, nil)
+
+		resp, apiErr := backend.ConstructionSubmit(ctx, &types.ConstructionSubmitRequest{
+			NetworkIdentifier: pChainNetworkIdentifier,
+			SignedTransaction: wrappedSignedExportTx,
+		})
+
+		assert.Nil(t, apiErr)
+		assert.Equal(t, signedExportTxHash, resp.TransactionIdentifier.Hash)
+
+		clientMock.AssertExpectations(t)
+	})
 }
 
 func TestImportTxConstruction(t *testing.T) {
@@ -344,6 +370,7 @@ func TestImportTxConstruction(t *testing.T) {
 
 	signedImportTx := "0x000000000011000000050000000000000000000000000000000000000000000000000000000000000000000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa00000007000000003b8b87c0000000000000000000000001000000015445cd01d75b4a06b6b41939193c0b1c5544490d00000000000000007fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d500000001f52a5a6dd8f1b3fe05204bdab4f6bcb5a7059f88d0443c636f6c158f838dd1a8000000003d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa00000005000000003b9aca0000000001000000000000000100000009000000017403e32bb967e71902a988b7da635b4bca2475eedbfd23176610a88162f3a92f20b61f2185825b04b7f8ee8c76427c8dc80eb6091f9e594ef259a59856e5401b018ac25b4e"
 	signedImportTxSignature, _ := hex.DecodeString("7403e32bb967e71902a988b7da635b4bca2475eedbfd23176610a88162f3a92f20b61f2185825b04b7f8ee8c76427c8dc80eb6091f9e594ef259a59856e5401b01")
+	signedImportTxHash := "byyEVU6RL7PQNSVT8qEnybWGV5BbBfJwFV6bEDV5mkymXRz62"
 
 	wrappedSignedImportTx := `{"tx":"` + signedImportTx + `","signers":` + importSigners + `}`
 
@@ -457,9 +484,33 @@ func TestImportTxConstruction(t *testing.T) {
 		clientMock.AssertExpectations(t)
 	})
 
-	t.Run("hash endpoint", func(t *testing.T) {})
+	t.Run("hash endpoint", func(t *testing.T) {
+		resp, err := backend.ConstructionHash(ctx, &types.ConstructionHashRequest{
+			NetworkIdentifier: pChainNetworkIdentifier,
+			SignedTransaction: wrappedSignedImportTx,
+		})
+		assert.Nil(t, err)
+		assert.Equal(t, signedImportTxHash, resp.TransactionIdentifier.Hash)
 
-	t.Run("submit endpoint", func(t *testing.T) {})
+		clientMock.AssertExpectations(t)
+	})
+
+	t.Run("submit endpoint", func(t *testing.T) {
+		signedTxBytes, _ := formatting.Decode(formatting.Hex, signedImportTx)
+		txID, _ := ids.FromString(signedImportTxHash)
+
+		clientMock.On("IssueTx", ctx, signedTxBytes).Return(txID, nil)
+
+		resp, apiErr := backend.ConstructionSubmit(ctx, &types.ConstructionSubmitRequest{
+			NetworkIdentifier: pChainNetworkIdentifier,
+			SignedTransaction: wrappedSignedImportTx,
+		})
+
+		assert.Nil(t, apiErr)
+		assert.Equal(t, signedImportTxHash, resp.TransactionIdentifier.Hash)
+
+		clientMock.AssertExpectations(t)
+	})
 }
 
 func TestAddValidatorTxConstruction(t *testing.T) {
@@ -545,6 +596,7 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 
 	signedTx := "0x00000000000c0000000500000000000000000000000000000000000000000000000000000000000000000000000000000001f52a5a6dd8f1b3fe05204bdab4f6bcb5a7059f88d0443c636f6c158f838dd1a8000000003d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa00000005000001d1a94a200000000001000000000000000077e1d5c6c289c49976f744749d54369d2129d7500000000062eb5de30000000062fdd2e3000001d1a94a2000000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa00000007000001d1a94a2000000000000000000000000001000000015445cd01d75b4a06b6b41939193c0b1c5544490d0000000b00000000000000000000000000000001cf7cd358e2e882449d68c1c8889889eaf247b72000030d400000000100000009000000017403e32bb967e71902a988b7da635b4bca2475eedbfd23176610a88162f3a92f20b61f2185825b04b7f8ee8c76427c8dc80eb6091f9e594ef259a59856e5401b01f45d31dd"
 	signedTxSignature, _ := hex.DecodeString("7403e32bb967e71902a988b7da635b4bca2475eedbfd23176610a88162f3a92f20b61f2185825b04b7f8ee8c76427c8dc80eb6091f9e594ef259a59856e5401b01")
+	signedTxHash := "dhHkN5nDupSTDqudpbJXef1d4F1Zy3TUSbYqmWJBH6qzggFBw"
 
 	wrappedSignedTx := `{"tx":"` + signedTx + `","signers":` + stakeSigners + `}`
 
@@ -656,9 +708,33 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 		clientMock.AssertExpectations(t)
 	})
 
-	t.Run("hash endpoint", func(t *testing.T) {})
+	t.Run("hash endpoint", func(t *testing.T) {
+		resp, err := backend.ConstructionHash(ctx, &types.ConstructionHashRequest{
+			NetworkIdentifier: pChainNetworkIdentifier,
+			SignedTransaction: wrappedSignedTx,
+		})
+		assert.Nil(t, err)
+		assert.Equal(t, signedTxHash, resp.TransactionIdentifier.Hash)
 
-	t.Run("submit endpoint", func(t *testing.T) {})
+		clientMock.AssertExpectations(t)
+	})
+
+	t.Run("submit endpoint", func(t *testing.T) {
+		signedTxBytes, _ := formatting.Decode(formatting.Hex, signedTx)
+		txID, _ := ids.FromString(signedTxHash)
+
+		clientMock.On("IssueTx", ctx, signedTxBytes).Return(txID, nil)
+
+		resp, apiErr := backend.ConstructionSubmit(ctx, &types.ConstructionSubmitRequest{
+			NetworkIdentifier: pChainNetworkIdentifier,
+			SignedTransaction: wrappedSignedTx,
+		})
+
+		assert.Nil(t, apiErr)
+		assert.Equal(t, signedTxHash, resp.TransactionIdentifier.Hash)
+
+		clientMock.AssertExpectations(t)
+	})
 }
 
 func TestAddDelegatorTxConstruction(t *testing.T) {
@@ -741,6 +817,7 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 
 	signedTx := "0x00000000000e0000000500000000000000000000000000000000000000000000000000000000000000000000000000000001f52a5a6dd8f1b3fe05204bdab4f6bcb5a7059f88d0443c636f6c158f838dd1a8000000003d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa0000000500000005d21dba0000000001000000000000000077e1d5c6c289c49976f744749d54369d2129d7500000000062eb5de30000000062fdd2e300000005d21dba00000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa0000000700000005d21dba00000000000000000000000001000000015445cd01d75b4a06b6b41939193c0b1c5544490d0000000b00000000000000000000000000000001cf7cd358e2e882449d68c1c8889889eaf247b7200000000100000009000000017403e32bb967e71902a988b7da635b4bca2475eedbfd23176610a88162f3a92f20b61f2185825b04b7f8ee8c76427c8dc80eb6091f9e594ef259a59856e5401b011ea948a2"
 	signedTxSignature, _ := hex.DecodeString("7403e32bb967e71902a988b7da635b4bca2475eedbfd23176610a88162f3a92f20b61f2185825b04b7f8ee8c76427c8dc80eb6091f9e594ef259a59856e5401b01")
+	signedTxHash := "R8k9kbffu2AQHqaMKBEFxFnzUuS4pSG1i8XEFQX8Sn8ogrP7j"
 
 	wrappedSignedTx := `{"tx":"` + signedTx + `","signers":` + stakeSigners + `}`
 
@@ -852,7 +929,31 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 		clientMock.AssertExpectations(t)
 	})
 
-	t.Run("hash endpoint", func(t *testing.T) {})
+	t.Run("hash endpoint", func(t *testing.T) {
+		resp, err := backend.ConstructionHash(ctx, &types.ConstructionHashRequest{
+			NetworkIdentifier: pChainNetworkIdentifier,
+			SignedTransaction: wrappedSignedTx,
+		})
+		assert.Nil(t, err)
+		assert.Equal(t, signedTxHash, resp.TransactionIdentifier.Hash)
 
-	t.Run("submit endpoint", func(t *testing.T) {})
+		clientMock.AssertExpectations(t)
+	})
+
+	t.Run("submit endpoint", func(t *testing.T) {
+		signedTxBytes, _ := formatting.Decode(formatting.Hex, signedTx)
+		txID, _ := ids.FromString(signedTxHash)
+
+		clientMock.On("IssueTx", ctx, signedTxBytes).Return(txID, nil)
+
+		resp, apiErr := backend.ConstructionSubmit(ctx, &types.ConstructionSubmitRequest{
+			NetworkIdentifier: pChainNetworkIdentifier,
+			SignedTransaction: wrappedSignedTx,
+		})
+
+		assert.Nil(t, apiErr)
+		assert.Equal(t, signedTxHash, resp.TransactionIdentifier.Hash)
+
+		clientMock.AssertExpectations(t)
+	})
 }

--- a/service/backend/pchain/construction_test.go
+++ b/service/backend/pchain/construction_test.go
@@ -157,8 +157,22 @@ func TestExportTxConstruction(t *testing.T) {
 		},
 	}
 
+	signedExportTx := "0x0000000000120000000500000000000000000000000000000000000000000000000000000000000000000000000000000001f52a5a6dd8f1b3fe05204bdab4f6bcb5a7059f88d0443c636f6c158f838dd1a8000000003d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa00000005000000003b9aca000000000100000000000000007fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d5000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa00000007000000003b8b87c0000000000000000000000001000000015445cd01d75b4a06b6b41939193c0b1c5544490d0000000100000009000000017403e32bb967e71902a988b7da635b4bca2475eedbfd23176610a88162f3a92f20b61f2185825b04b7f8ee8c76427c8dc80eb6091f9e594ef259a59856e5401b0137dc0dc4"
+	signedExportTxSignature, _ := hex.DecodeString("7403e32bb967e71902a988b7da635b4bca2475eedbfd23176610a88162f3a92f20b61f2185825b04b7f8ee8c76427c8dc80eb6091f9e594ef259a59856e5401b01")
+
 	wrappedTxFormat := `{"tx":"%s","signers":%s,"destination_chain":"%s","destination_chain_id":"%s"}`
 	wrappedUnsignedExportTx := fmt.Sprintf(wrappedTxFormat, unsignedExportTx, exportSigners, "C", cChainID.String())
+	wrappedSignedExportTx := fmt.Sprintf(wrappedTxFormat, signedExportTx, exportSigners, "C", cChainID.String())
+
+	signatures := []*types.Signature{{
+		SigningPayload: &types.SigningPayload{
+			AccountIdentifier: pAccountIdentifier,
+			Bytes:             unsignedExportTxHash,
+			SignatureType:     types.EcdsaRecovery,
+		},
+		SignatureType: types.EcdsaRecovery,
+		Bytes:         signedExportTxSignature,
+	}}
 
 	ctx := context.Background()
 	clientMock := &mocks.PChainClient{}
@@ -214,11 +228,51 @@ func TestExportTxConstruction(t *testing.T) {
 		clientMock.AssertExpectations(t)
 	})
 
-	t.Run("parse endpoint (unsigned)", func(t *testing.T) {})
+	t.Run("parse endpoint (unsigned)", func(t *testing.T) {
+		resp, err := backend.ConstructionParse(
+			ctx,
+			&types.ConstructionParseRequest{
+				NetworkIdentifier: pChainNetworkIdentifier,
+				Transaction:       wrappedUnsignedExportTx,
+				Signed:            false,
+			},
+		)
+		assert.Nil(t, err)
+		assert.Nil(t, resp.AccountIdentifierSigners)
+		assert.Equal(t, exportOperations, resp.Operations)
 
-	t.Run("combine endpoint", func(t *testing.T) {})
+		clientMock.AssertExpectations(t)
+	})
 
-	t.Run("parse endpoint (signed)", func(t *testing.T) {})
+	t.Run("combine endpoint", func(t *testing.T) {
+		resp, err := backend.ConstructionCombine(
+			ctx,
+			&types.ConstructionCombineRequest{
+				NetworkIdentifier:   pChainNetworkIdentifier,
+				UnsignedTransaction: wrappedUnsignedExportTx,
+				Signatures:          signatures,
+			},
+		)
+
+		assert.Nil(t, err)
+		assert.Equal(t, wrappedSignedExportTx, resp.SignedTransaction)
+	})
+
+	t.Run("parse endpoint (signed)", func(t *testing.T) {
+		resp, err := backend.ConstructionParse(
+			ctx,
+			&types.ConstructionParseRequest{
+				NetworkIdentifier: pChainNetworkIdentifier,
+				Transaction:       wrappedSignedExportTx,
+				Signed:            true,
+			},
+		)
+		assert.Nil(t, err)
+		assert.Equal(t, signers, resp.AccountIdentifierSigners)
+		assert.Equal(t, exportOperations, resp.Operations)
+
+		clientMock.AssertExpectations(t)
+	})
 
 	t.Run("hash endpoint", func(t *testing.T) {})
 
@@ -288,6 +342,21 @@ func TestImportTxConstruction(t *testing.T) {
 		},
 	}
 
+	signedImportTx := "0x000000000011000000050000000000000000000000000000000000000000000000000000000000000000000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa00000007000000003b8b87c0000000000000000000000001000000015445cd01d75b4a06b6b41939193c0b1c5544490d00000000000000007fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d500000001f52a5a6dd8f1b3fe05204bdab4f6bcb5a7059f88d0443c636f6c158f838dd1a8000000003d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa00000005000000003b9aca0000000001000000000000000100000009000000017403e32bb967e71902a988b7da635b4bca2475eedbfd23176610a88162f3a92f20b61f2185825b04b7f8ee8c76427c8dc80eb6091f9e594ef259a59856e5401b018ac25b4e"
+	signedImportTxSignature, _ := hex.DecodeString("7403e32bb967e71902a988b7da635b4bca2475eedbfd23176610a88162f3a92f20b61f2185825b04b7f8ee8c76427c8dc80eb6091f9e594ef259a59856e5401b01")
+
+	wrappedSignedImportTx := `{"tx":"` + signedImportTx + `","signers":` + importSigners + `}`
+
+	signatures := []*types.Signature{{
+		SigningPayload: &types.SigningPayload{
+			AccountIdentifier: cAccountIdentifier,
+			Bytes:             unsignedImportTxHash,
+			SignatureType:     types.EcdsaRecovery,
+		},
+		SignatureType: types.EcdsaRecovery,
+		Bytes:         signedImportTxSignature,
+	}}
+
 	ctx := context.Background()
 	clientMock := &mocks.PChainClient{}
 	backend := NewBackend(clientMock, nil, avaxAssetID, pChainNetworkIdentifier)
@@ -342,11 +411,51 @@ func TestImportTxConstruction(t *testing.T) {
 		clientMock.AssertExpectations(t)
 	})
 
-	t.Run("parse endpoint (unsigned)", func(t *testing.T) {})
+	t.Run("parse endpoint (unsigned)", func(t *testing.T) {
+		resp, err := backend.ConstructionParse(
+			ctx,
+			&types.ConstructionParseRequest{
+				NetworkIdentifier: pChainNetworkIdentifier,
+				Transaction:       wrappedUnsignedImportTx,
+				Signed:            false,
+			},
+		)
+		assert.Nil(t, err)
+		assert.Nil(t, resp.AccountIdentifierSigners)
+		assert.Equal(t, importOperations, resp.Operations)
 
-	t.Run("combine endpoint", func(t *testing.T) {})
+		clientMock.AssertExpectations(t)
+	})
 
-	t.Run("parse endpoint (signed)", func(t *testing.T) {})
+	t.Run("combine endpoint", func(t *testing.T) {
+		resp, err := backend.ConstructionCombine(
+			ctx,
+			&types.ConstructionCombineRequest{
+				NetworkIdentifier:   pChainNetworkIdentifier,
+				UnsignedTransaction: wrappedUnsignedImportTx,
+				Signatures:          signatures,
+			},
+		)
+
+		assert.Nil(t, err)
+		assert.Equal(t, wrappedSignedImportTx, resp.SignedTransaction)
+	})
+
+	t.Run("parse endpoint (signed)", func(t *testing.T) {
+		resp, err := backend.ConstructionParse(
+			ctx,
+			&types.ConstructionParseRequest{
+				NetworkIdentifier: pChainNetworkIdentifier,
+				Transaction:       wrappedSignedImportTx,
+				Signed:            true,
+			},
+		)
+		assert.Nil(t, err)
+		assert.Equal(t, signers, resp.AccountIdentifierSigners)
+		assert.Equal(t, importOperations, resp.Operations)
+
+		clientMock.AssertExpectations(t)
+	})
 
 	t.Run("hash endpoint", func(t *testing.T) {})
 
@@ -434,6 +543,21 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 		},
 	}
 
+	signedTx := "0x00000000000c0000000500000000000000000000000000000000000000000000000000000000000000000000000000000001f52a5a6dd8f1b3fe05204bdab4f6bcb5a7059f88d0443c636f6c158f838dd1a8000000003d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa00000005000001d1a94a200000000001000000000000000077e1d5c6c289c49976f744749d54369d2129d7500000000062eb5de30000000062fdd2e3000001d1a94a2000000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa00000007000001d1a94a2000000000000000000000000001000000015445cd01d75b4a06b6b41939193c0b1c5544490d0000000b00000000000000000000000000000001cf7cd358e2e882449d68c1c8889889eaf247b72000030d400000000100000009000000017403e32bb967e71902a988b7da635b4bca2475eedbfd23176610a88162f3a92f20b61f2185825b04b7f8ee8c76427c8dc80eb6091f9e594ef259a59856e5401b01f45d31dd"
+	signedTxSignature, _ := hex.DecodeString("7403e32bb967e71902a988b7da635b4bca2475eedbfd23176610a88162f3a92f20b61f2185825b04b7f8ee8c76427c8dc80eb6091f9e594ef259a59856e5401b01")
+
+	wrappedSignedTx := `{"tx":"` + signedTx + `","signers":` + stakeSigners + `}`
+
+	signatures := []*types.Signature{{
+		SigningPayload: &types.SigningPayload{
+			AccountIdentifier: cAccountIdentifier,
+			Bytes:             unsignedTxHash,
+			SignatureType:     types.EcdsaRecovery,
+		},
+		SignatureType: types.EcdsaRecovery,
+		Bytes:         signedTxSignature,
+	}}
+
 	ctx := context.Background()
 	clientMock := &mocks.PChainClient{}
 	backend := NewBackend(clientMock, nil, avaxAssetID, pChainNetworkIdentifier)
@@ -486,11 +610,51 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 		clientMock.AssertExpectations(t)
 	})
 
-	t.Run("parse endpoint (unsigned)", func(t *testing.T) {})
+	t.Run("parse endpoint (unsigned)", func(t *testing.T) {
+		resp, err := backend.ConstructionParse(
+			ctx,
+			&types.ConstructionParseRequest{
+				NetworkIdentifier: pChainNetworkIdentifier,
+				Transaction:       wrappedUnsignedTx,
+				Signed:            false,
+			},
+		)
+		assert.Nil(t, err)
+		assert.Nil(t, resp.AccountIdentifierSigners)
+		assert.Equal(t, operations, resp.Operations)
 
-	t.Run("combine endpoint", func(t *testing.T) {})
+		clientMock.AssertExpectations(t)
+	})
 
-	t.Run("parse endpoint (signed)", func(t *testing.T) {})
+	t.Run("combine endpoint", func(t *testing.T) {
+		resp, err := backend.ConstructionCombine(
+			ctx,
+			&types.ConstructionCombineRequest{
+				NetworkIdentifier:   pChainNetworkIdentifier,
+				UnsignedTransaction: wrappedUnsignedTx,
+				Signatures:          signatures,
+			},
+		)
+
+		assert.Nil(t, err)
+		assert.Equal(t, wrappedSignedTx, resp.SignedTransaction)
+	})
+
+	t.Run("parse endpoint (signed)", func(t *testing.T) {
+		resp, err := backend.ConstructionParse(
+			ctx,
+			&types.ConstructionParseRequest{
+				NetworkIdentifier: pChainNetworkIdentifier,
+				Transaction:       wrappedSignedTx,
+				Signed:            true,
+			},
+		)
+		assert.Nil(t, err)
+		assert.Equal(t, signers, resp.AccountIdentifierSigners)
+		assert.Equal(t, operations, resp.Operations)
+
+		clientMock.AssertExpectations(t)
+	})
 
 	t.Run("hash endpoint", func(t *testing.T) {})
 
@@ -575,6 +739,21 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 		},
 	}
 
+	signedTx := "0x00000000000e0000000500000000000000000000000000000000000000000000000000000000000000000000000000000001f52a5a6dd8f1b3fe05204bdab4f6bcb5a7059f88d0443c636f6c158f838dd1a8000000003d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa0000000500000005d21dba0000000001000000000000000077e1d5c6c289c49976f744749d54369d2129d7500000000062eb5de30000000062fdd2e300000005d21dba00000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa0000000700000005d21dba00000000000000000000000001000000015445cd01d75b4a06b6b41939193c0b1c5544490d0000000b00000000000000000000000000000001cf7cd358e2e882449d68c1c8889889eaf247b7200000000100000009000000017403e32bb967e71902a988b7da635b4bca2475eedbfd23176610a88162f3a92f20b61f2185825b04b7f8ee8c76427c8dc80eb6091f9e594ef259a59856e5401b011ea948a2"
+	signedTxSignature, _ := hex.DecodeString("7403e32bb967e71902a988b7da635b4bca2475eedbfd23176610a88162f3a92f20b61f2185825b04b7f8ee8c76427c8dc80eb6091f9e594ef259a59856e5401b01")
+
+	wrappedSignedTx := `{"tx":"` + signedTx + `","signers":` + stakeSigners + `}`
+
+	signatures := []*types.Signature{{
+		SigningPayload: &types.SigningPayload{
+			AccountIdentifier: cAccountIdentifier,
+			Bytes:             unsignedTxHash,
+			SignatureType:     types.EcdsaRecovery,
+		},
+		SignatureType: types.EcdsaRecovery,
+		Bytes:         signedTxSignature,
+	}}
+
 	ctx := context.Background()
 	clientMock := &mocks.PChainClient{}
 	backend := NewBackend(clientMock, nil, avaxAssetID, pChainNetworkIdentifier)
@@ -627,11 +806,51 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 		clientMock.AssertExpectations(t)
 	})
 
-	t.Run("parse endpoint (unsigned)", func(t *testing.T) {})
+	t.Run("parse endpoint (unsigned)", func(t *testing.T) {
+		resp, err := backend.ConstructionParse(
+			ctx,
+			&types.ConstructionParseRequest{
+				NetworkIdentifier: pChainNetworkIdentifier,
+				Transaction:       wrappedUnsignedTx,
+				Signed:            false,
+			},
+		)
+		assert.Nil(t, err)
+		assert.Nil(t, resp.AccountIdentifierSigners)
+		assert.Equal(t, operations, resp.Operations)
 
-	t.Run("combine endpoint", func(t *testing.T) {})
+		clientMock.AssertExpectations(t)
+	})
 
-	t.Run("parse endpoint (signed)", func(t *testing.T) {})
+	t.Run("combine endpoint", func(t *testing.T) {
+		resp, err := backend.ConstructionCombine(
+			ctx,
+			&types.ConstructionCombineRequest{
+				NetworkIdentifier:   pChainNetworkIdentifier,
+				UnsignedTransaction: wrappedUnsignedTx,
+				Signatures:          signatures,
+			},
+		)
+
+		assert.Nil(t, err)
+		assert.Equal(t, wrappedSignedTx, resp.SignedTransaction)
+	})
+
+	t.Run("parse endpoint (signed)", func(t *testing.T) {
+		resp, err := backend.ConstructionParse(
+			ctx,
+			&types.ConstructionParseRequest{
+				NetworkIdentifier: pChainNetworkIdentifier,
+				Transaction:       wrappedSignedTx,
+				Signed:            true,
+			},
+		)
+		assert.Nil(t, err)
+		assert.Equal(t, signers, resp.AccountIdentifierSigners)
+		assert.Equal(t, operations, resp.Operations)
+
+		clientMock.AssertExpectations(t)
+	})
 
 	t.Run("hash endpoint", func(t *testing.T) {})
 


### PR DESCRIPTION
Parse, combine, hash and submit implementations for P-chain. Most of the logic is written to support c-chain atomic tx support with minimal effort afterwards.