### PR TITLE
Account and block endpoint fixes

### DIFF
--- a/mapper/transaction.go
+++ b/mapper/transaction.go
@@ -245,26 +245,18 @@ func CrossChainTransactions(
 		return nil, err
 	}
 
-	ops := []*types.Operation{}
 	for _, tx := range atomicTxs {
-		txOps, err := crossChainTransaction(len(ops), avaxAssetID, tx)
+		txOps, err := crossChainTransaction(0, avaxAssetID, tx)
 		if err != nil {
 			return nil, err
 		}
-		ops = append(ops, txOps...)
+		transactions = append(transactions, &types.Transaction{
+			TransactionIdentifier: &types.TransactionIdentifier{
+				Hash: tx.ID().String(),
+			},
+			Operations: txOps,
+		})
 	}
-
-	// TODO: migrate to using atomic transaction ID instead of marking as a block
-	// transaction
-	//
-	// NOTE: We need to be very careful about this because it will require
-	// integrators to re-index the chain to get the new result.
-	transactions = append(transactions, &types.Transaction{
-		TransactionIdentifier: &types.TransactionIdentifier{
-			Hash: block.Hash().String(),
-		},
-		Operations: ops,
-	})
 
 	return transactions, nil
 }

--- a/service/backend/cchainatomictx/account_test.go
+++ b/service/backend/cchainatomictx/account_test.go
@@ -2,12 +2,14 @@ package cchainatomictx
 
 import (
 	"context"
+	"math/big"
 	"strconv"
 	"testing"
 
 	"github.com/ava-labs/avalanchego/api"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	ethtypes "github.com/ava-labs/coreth/core/types"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -26,7 +28,10 @@ var utxos = []utxo{
 	{"2QmMXKS6rKQMnEh2XYZ4ZWCJmy8RpD3LyVZWxBG25t4N1JJqxY:1", 1_500_000},
 	{"2QmMXKS6rKQMnEh2XYZ4ZWCJmy8RpD3LyVZWxBG25t4N1JJqxY:1", 1_500_000}, // duplicate
 	{"23CLURk1Czf1aLui1VdcuWSiDeFskfp3Sn8TQG7t6NKfeQRYDj:4", 2_000_000}, // out of order
+}
 
+var blockHeader = &ethtypes.Header{
+	Number: big.NewInt(42),
 }
 
 func TestAccountBalance(t *testing.T) {
@@ -40,6 +45,8 @@ func TestAccountBalance(t *testing.T) {
 
 		utxos := [][]byte{utxo0Bytes, utxo1Bytes}
 
+		var nilBigInt *big.Int
+		evmMock.On("HeaderByNumber", mock.Anything, nilBigInt).Return(blockHeader, nil).Twice()
 		evmMock.
 			On("GetAtomicUTXOs", mock.Anything, []string{accountAddress}, "P", backend.getUTXOsPageSize, "", "").
 			Return(utxos, api.Index{}, nil)
@@ -76,6 +83,8 @@ func TestAccountCoins(t *testing.T) {
 		utxo2Bytes := makeUtxoBytes(t, backend, utxos[2].id, utxos[2].amount)
 		utxo3Bytes := makeUtxoBytes(t, backend, utxos[3].id, utxos[3].amount)
 
+		var nilBigInt *big.Int
+		evmMock.On("HeaderByNumber", mock.Anything, nilBigInt).Return(blockHeader, nil).Twice()
 		evmMock.
 			On("GetAtomicUTXOs", mock.Anything, []string{accountAddress}, "P", backend.getUTXOsPageSize, "", "").
 			Return([][]byte{utxo0Bytes, utxo1Bytes}, api.Index{Address: accountAddress, UTXO: utxos[1].id}, nil)

--- a/service/backend/pchain/account.go
+++ b/service/backend/pchain/account.go
@@ -63,6 +63,8 @@ func (b *Backend) AccountBalance(ctx context.Context, req *types.AccountBalanceR
 		balanceValue = balance.LockedNotStakeable
 	case pmapper.SubAccountTypeStaked:
 		balanceValue = balance.Staked
+	case pmapper.SubAccountTypeSharedMemory:
+		balanceValue = balance.Total
 	case "": // Defaults to total balance
 		balanceValue = balance.Total
 	default:
@@ -139,7 +141,7 @@ func (b *Backend) fetchBalance(ctx context.Context, addrString string, fetchImpo
 		return 0, nil, service.WrapError(service.ErrInvalidInput, "unable to convert address")
 	}
 
-	height, utxos, stakedUTXOBytes, typedErr := b.fetchUTXOsAndStakedOutputs(ctx, addr, true, fetchImportable)
+	height, utxos, stakedUTXOBytes, typedErr := b.fetchUTXOsAndStakedOutputs(ctx, addr, !fetchImportable, fetchImportable)
 	if typedErr != nil {
 		return 0, nil, typedErr
 	}


### PR DESCRIPTION
- Adding block identifier to C-chain atomic balance requests
- Switching to use C-chain atomic tx id instead of block id for the C-chain atomic transactions in block parsing
- Adding shared memory balance support for P-chain