### PR TITLE
C chain construction rest

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,8 @@ run:
 issues:
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0
+  exclude:
+    - "G114: Use of net/http serve function that has no support for setting timeouts"
 
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.

--- a/mapper/cchainatomictx/tx_parser.go
+++ b/mapper/cchainatomictx/tx_parser.go
@@ -1,0 +1,192 @@
+package cchainatomictx
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"strconv"
+
+	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/ava-labs/coreth/plugin/evm"
+	"github.com/coinbase/rosetta-sdk-go/types"
+
+	"github.com/ava-labs/avalanche-rosetta/mapper"
+)
+
+var (
+	errUnknownDestinationChain  = errors.New("unknown destination chain")
+	errNoMatchingInputAddresses = errors.New("no matching input addresses")
+)
+
+type TxParser struct {
+	hrp             string
+	chainIDs        map[string]string
+	inputTxAccounts map[string]*types.AccountIdentifier
+}
+
+func NewTxParser(hrp string, chainIDs map[string]string, inputTxAccounts map[string]*types.AccountIdentifier) *TxParser {
+	return &TxParser{hrp: hrp, chainIDs: chainIDs, inputTxAccounts: inputTxAccounts}
+}
+
+func (t *TxParser) Parse(tx evm.Tx) ([]*types.Operation, error) {
+	switch unsignedTx := tx.UnsignedAtomicTx.(type) {
+	case *evm.UnsignedExportTx:
+		return t.parseExportTx(unsignedTx)
+	case *evm.UnsignedImportTx:
+		return t.parseImportTx(unsignedTx)
+	default:
+		return nil, fmt.Errorf("unsupported tx type")
+	}
+}
+
+func (t *TxParser) parseExportTx(exportTx *evm.UnsignedExportTx) ([]*types.Operation, error) {
+	operations := []*types.Operation{}
+	ins := t.insToOperations(0, mapper.OpExport, exportTx.Ins)
+
+	destinationChainID := exportTx.DestinationChain.String()
+	chainAlias, ok := t.chainIDs[destinationChainID]
+	if !ok {
+		return nil, errUnknownDestinationChain
+	}
+
+	operations = append(operations, ins...)
+	outs, err := t.exportedOutputsToOperations(len(ins), mapper.OpExport, chainAlias, exportTx.ExportedOutputs)
+	if err != nil {
+		return nil, err
+	}
+	operations = append(operations, outs...)
+
+	return operations, nil
+}
+
+func (t *TxParser) parseImportTx(importTx *evm.UnsignedImportTx) ([]*types.Operation, error) {
+	operations := []*types.Operation{}
+	ins, err := t.importedInToOperations(0, mapper.OpImport, importTx.ImportedInputs)
+	if err != nil {
+		return nil, err
+	}
+
+	operations = append(operations, ins...)
+	outs := t.outsToOperations(len(ins), mapper.OpImport, importTx.Outs)
+	operations = append(operations, outs...)
+
+	return operations, nil
+}
+
+func (t *TxParser) insToOperations(startIdx int64, opType string, ins []evm.EVMInput) []*types.Operation {
+	idx := startIdx
+	operations := []*types.Operation{}
+	for _, in := range ins {
+		inputAmount := new(big.Int).SetUint64(in.Amount)
+		operations = append(operations, &types.Operation{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: idx,
+			},
+			Type:    opType,
+			Account: &types.AccountIdentifier{Address: in.Address.Hex()},
+			// Negating input amount
+			Amount: mapper.AtomicAvaxAmount(new(big.Int).Neg(inputAmount)),
+		})
+		idx++
+	}
+	return operations
+}
+
+func (t *TxParser) importedInToOperations(startIdx int64, opType string, ins []*avax.TransferableInput) ([]*types.Operation, error) {
+	idx := startIdx
+	operations := []*types.Operation{}
+	for _, in := range ins {
+		inputAmount := new(big.Int).SetUint64(in.In.Amount())
+
+		utxoID := in.UTXOID.String()
+		account, ok := t.inputTxAccounts[utxoID]
+		if !ok {
+			return nil, errNoMatchingInputAddresses
+		}
+
+		operations = append(operations, &types.Operation{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: idx,
+			},
+			Type:    opType,
+			Account: account,
+			// Negating input amount
+			Amount: mapper.AtomicAvaxAmount(new(big.Int).Neg(inputAmount)),
+			CoinChange: &types.CoinChange{
+				CoinIdentifier: &types.CoinIdentifier{Identifier: utxoID},
+				CoinAction:     types.CoinSpent,
+			},
+		})
+		idx++
+	}
+	return operations, nil
+}
+
+func (t *TxParser) outsToOperations(startIdx int, opType string, outs []evm.EVMOutput) []*types.Operation {
+	idx := startIdx
+	operations := []*types.Operation{}
+	for _, out := range outs {
+		operations = append(operations, &types.Operation{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: int64(idx),
+			},
+			Account:           &types.AccountIdentifier{Address: out.Address.Hex()},
+			RelatedOperations: buildRelatedOperations(startIdx),
+			Type:              opType,
+			Amount: &types.Amount{
+				Value:    strconv.FormatUint(out.Amount, 10),
+				Currency: mapper.AtomicAvaxCurrency,
+			},
+		})
+		idx++
+	}
+	return operations
+}
+
+func (t *TxParser) exportedOutputsToOperations(
+	startIdx int,
+	opType string,
+	chainAlias string,
+	outs []*avax.TransferableOutput,
+) ([]*types.Operation, error) {
+	idx := startIdx
+	operations := []*types.Operation{}
+	for _, out := range outs {
+		var addr string
+		transferOutput := out.Output().(*secp256k1fx.TransferOutput)
+		if transferOutput != nil && len(transferOutput.Addrs) > 0 {
+			var err error
+			addr, err = address.Format(chainAlias, t.hrp, transferOutput.Addrs[0][:])
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		operations = append(operations, &types.Operation{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: int64(idx),
+			},
+			Account:           &types.AccountIdentifier{Address: addr},
+			RelatedOperations: buildRelatedOperations(startIdx),
+			Type:              opType,
+			Amount: &types.Amount{
+				Value:    strconv.FormatUint(out.Out.Amount(), 10),
+				Currency: mapper.AtomicAvaxCurrency,
+			},
+		})
+		idx++
+	}
+	return operations, nil
+}
+
+func buildRelatedOperations(idx int) []*types.OperationIdentifier {
+	var identifiers []*types.OperationIdentifier
+	for i := 0; i < idx; i++ {
+		identifiers = append(identifiers, &types.OperationIdentifier{
+			Index: int64(i),
+		})
+	}
+	return identifiers
+}

--- a/service/backend/cchainatomictx/backend.go
+++ b/service/backend/cchainatomictx/backend.go
@@ -53,14 +53,19 @@ func (b *Backend) ShouldHandleRequest(req interface{}) bool {
 	case *types.ConstructionPayloadsRequest:
 		return cmapper.IsAtomicOpType(r.Operations[0].Type)
 	case *types.ConstructionParseRequest:
-		return false
+		return b.isCchainAtomicTx(r.Transaction)
 	case *types.ConstructionCombineRequest:
-		return false
+		return b.isCchainAtomicTx(r.UnsignedTransaction)
 	case *types.ConstructionHashRequest:
-		return false
+		return b.isCchainAtomicTx(r.SignedTransaction)
 	case *types.ConstructionSubmitRequest:
-		return false
+		return b.isCchainAtomicTx(r.SignedTransaction)
 	}
 
 	return false
+}
+
+func (b *Backend) isCchainAtomicTx(transaction string) bool {
+	_, err := b.parsePayloadTxFromString(transaction)
+	return err == nil
 }

--- a/service/backend/cchainatomictx/backend_test.go
+++ b/service/backend/cchainatomictx/backend_test.go
@@ -3,65 +3,138 @@ package cchainatomictx
 import (
 	"testing"
 
-	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/coreth/plugin/evm"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ava-labs/avalanche-rosetta/mapper"
+	cmapper "github.com/ava-labs/avalanche-rosetta/mapper/cchainatomictx"
 	"github.com/ava-labs/avalanche-rosetta/service"
 )
 
 func TestShouldHandleRequest(t *testing.T) {
-	networkIdentifier := &types.NetworkIdentifier{
+	cChainNetworkIdentifier := &types.NetworkIdentifier{
 		Blockchain: service.BlockchainName,
 		Network:    mapper.FujiNetwork,
 	}
 
-	cBech32Address := "C-avax18xxz9e8323836t5wtpqh6fmrsjnksd6mka3gh7"
-	cEvmAddress := "0x8cBE7BdCd93FD767349074CBdD6CB69127eb0950"
+	bech32AccountIdentifier := &types.AccountIdentifier{Address: "C-avax1us3us4s4mv0g85vxjm8va04ewdl27wcwnqwejf"}
+	evmAccountIdentifier := &types.AccountIdentifier{Address: "0x30cE0c38f953eE9CD5fbc247e63DE68D3263144b"}
 
-	backend := NewBackend(nil, ids.Empty)
+	atomicOperations := []*types.Operation{
+		{Type: mapper.OpImport},
+	}
 
-	t.Run("should handle c-chain bech32 request", func(t *testing.T) {
-		assert.True(t, backend.ShouldHandleRequest(
-			&types.ConstructionDeriveRequest{
-				NetworkIdentifier: networkIdentifier,
-				Metadata: map[string]interface{}{
-					mapper.MetaAddressFormat: mapper.AddressFormatBech32,
-				},
+	evmOperations := []*types.Operation{
+		{Type: mapper.OpCall},
+	}
+
+	backend := &Backend{
+		codec:        evm.Codec,
+		codecVersion: 0,
+	}
+
+	atomicTxString := `{"tx":"0x000000000000000000057fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d500000000000000000000000000000000000000000000000000000000000000000000000288ae5dd070e6d74f16c26358cd4a8f43746d4d338b5b75b668741c6d95816af5000000023d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa000000050000000000e4e1c00000000100000000b9a824340e1b94f27500cdfcbf8eaa9d4ee5e57b2823cb8b158de17689916c74000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa0000000500000000004c4b400000000100000000000000013158e80abd5a1e1aa716003c9db096792c37962100000000012c7a123d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa000000020000000900000001a06d20d1d175b1e1d2b6e647ab5321717967de7e9367c28df8c0e20634ec7827019fe38e8d4f123f8e5286f3236db8dbb419e264628e2f17330a6c8da60d3424010000000900000001a06d20d1d175b1e1d2b6e647ab5321717967de7e9367c28df8c0e20634ec7827019fe38e8d4f123f8e5286f3236db8dbb419e264628e2f17330a6c8da60d342401dc68b1fc","signers":[{"coin_identifier":"23CLURk1Czf1aLui1VdcuWSiDeFskfp3Sn8TQG7t6NKfeQRYDj:2","account_identifier":{"address":"P-fuji1wmd9dfrqpud6daq0cde47u0r7pkrr46ep60399"}},{"coin_identifier":"2QmMXKS6rKQMnEh2XYZ4ZWCJmy8RpD3LyVZWxBG25t4N1JJqxY:1","account_identifier":{"address":"P-fuji1wmd9dfrqpud6daq0cde47u0r7pkrr46ep60399"}}]}`
+
+	nonAtomicTxString := "evmtxstring"
+
+	t.Run("return true for c-chain atomic tx requests", func(t *testing.T) {
+		assert.True(t, backend.ShouldHandleRequest(&types.AccountBalanceRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			AccountIdentifier: bech32AccountIdentifier,
+		}))
+		assert.True(t, backend.ShouldHandleRequest(&types.AccountCoinsRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			AccountIdentifier: bech32AccountIdentifier,
+		}))
+		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionDeriveRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			Metadata: map[string]interface{}{
+				mapper.MetaAddressFormat: mapper.AddressFormatBech32,
 			},
-		))
-		assert.True(t, backend.ShouldHandleRequest(
-			&types.AccountBalanceRequest{
-				NetworkIdentifier: networkIdentifier,
-				AccountIdentifier: &types.AccountIdentifier{Address: cBech32Address},
+		}))
+		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionMetadataRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			Options: map[string]interface{}{
+				cmapper.MetadataAtomicTxGas: 123,
 			},
-		))
-		assert.True(t, backend.ShouldHandleRequest(
-			&types.AccountCoinsRequest{
-				NetworkIdentifier: networkIdentifier,
-				AccountIdentifier: &types.AccountIdentifier{Address: cBech32Address},
-			},
-		))
+		}))
+		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionPreprocessRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			Operations:        atomicOperations,
+		}))
+		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionPayloadsRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			Operations:        atomicOperations,
+		}))
+		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionParseRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			Transaction:       atomicTxString,
+			Signed:            true,
+		}))
+		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionCombineRequest{
+			NetworkIdentifier:   cChainNetworkIdentifier,
+			UnsignedTransaction: atomicTxString,
+		}))
+		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionHashRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			SignedTransaction: atomicTxString,
+		}))
+		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionSubmitRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			SignedTransaction: atomicTxString,
+		}))
 	})
 
-	t.Run("should not handle regular c-chain request", func(t *testing.T) {
-		assert.False(t, backend.ShouldHandleRequest(
-			&types.ConstructionDeriveRequest{
-				NetworkIdentifier: networkIdentifier,
-			},
-		))
-		assert.False(t, backend.ShouldHandleRequest(
-			&types.AccountBalanceRequest{
-				NetworkIdentifier: networkIdentifier,
-				AccountIdentifier: &types.AccountIdentifier{Address: cEvmAddress},
-			},
-		))
-		assert.False(t, backend.ShouldHandleRequest(
-			&types.AccountCoinsRequest{
-				NetworkIdentifier: networkIdentifier,
-				AccountIdentifier: &types.AccountIdentifier{Address: cEvmAddress},
-			},
-		))
+	t.Run("return false for other c-chain requests", func(t *testing.T) {
+		assert.False(t, backend.ShouldHandleRequest(&types.AccountBalanceRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			AccountIdentifier: evmAccountIdentifier,
+		}))
+		assert.False(t, backend.ShouldHandleRequest(&types.AccountCoinsRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			AccountIdentifier: evmAccountIdentifier,
+		}))
+		assert.False(t, backend.ShouldHandleRequest(&types.ConstructionDeriveRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+		}))
+		assert.False(t, backend.ShouldHandleRequest(&types.ConstructionMetadataRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+		}))
+		assert.False(t, backend.ShouldHandleRequest(&types.ConstructionPreprocessRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			Operations:        evmOperations,
+		}))
+		assert.False(t, backend.ShouldHandleRequest(&types.ConstructionPayloadsRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			Operations:        evmOperations,
+		}))
+		assert.False(t, backend.ShouldHandleRequest(&types.ConstructionParseRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			Transaction:       nonAtomicTxString,
+		}))
+		assert.False(t, backend.ShouldHandleRequest(&types.ConstructionCombineRequest{
+			NetworkIdentifier:   cChainNetworkIdentifier,
+			UnsignedTransaction: nonAtomicTxString,
+		}))
+		assert.False(t, backend.ShouldHandleRequest(&types.ConstructionHashRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			SignedTransaction: nonAtomicTxString,
+		}))
+		assert.False(t, backend.ShouldHandleRequest(&types.ConstructionSubmitRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			SignedTransaction: nonAtomicTxString,
+		}))
+
+		// Backend does not support /block and /network endpoints
+		assert.False(t, backend.ShouldHandleRequest(&types.BlockRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+		}))
+		assert.False(t, backend.ShouldHandleRequest(&types.BlockTransactionRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+		}))
+		assert.False(t, backend.ShouldHandleRequest(&types.NetworkRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+		}))
 	})
 }

--- a/service/backend/cchainatomictx/construction.go
+++ b/service/backend/cchainatomictx/construction.go
@@ -309,10 +309,26 @@ func getTxCreds(
 	return nil, errUnknownTxType
 }
 
-func (b *Backend) ConstructionHash(ctx context.Context, req *types.ConstructionHashRequest) (*types.TransactionIdentifierResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+func (b *Backend) ConstructionHash(
+	ctx context.Context,
+	req *types.ConstructionHashRequest,
+) (*types.TransactionIdentifierResponse, *types.Error) {
+	rosettaTx, err := b.parsePayloadTxFromString(req.SignedTransaction)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	return common.HashTx(rosettaTx)
 }
 
-func (b *Backend) ConstructionSubmit(ctx context.Context, req *types.ConstructionSubmitRequest) (*types.TransactionIdentifierResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+func (b *Backend) ConstructionSubmit(
+	ctx context.Context,
+	req *types.ConstructionSubmitRequest,
+) (*types.TransactionIdentifierResponse, *types.Error) {
+	rosettaTx, err := b.parsePayloadTxFromString(req.SignedTransaction)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	return common.SubmitTx(ctx, b.cClient, rosettaTx)
 }

--- a/service/backend/cchainatomictx/construction.go
+++ b/service/backend/cchainatomictx/construction.go
@@ -2,12 +2,16 @@ package cchainatomictx
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/crypto"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/coreth/plugin/evm"
 	"github.com/coinbase/rosetta-sdk-go/parser"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -16,6 +20,12 @@ import (
 	cmapper "github.com/ava-labs/avalanche-rosetta/mapper/cchainatomictx"
 	"github.com/ava-labs/avalanche-rosetta/service"
 	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
+)
+
+var (
+	errUnknownTxType = errors.New("unknown tx type")
+	errUndecodableTx = errors.New("undecodable transaction")
+	errNoTxGiven     = errors.New("no transaction was given")
 )
 
 func (b *Backend) ConstructionDerive(ctx context.Context, req *types.ConstructionDeriveRequest) (*types.ConstructionDeriveResponse, *types.Error) {
@@ -203,11 +213,100 @@ func (b *Backend) ConstructionPayloads(ctx context.Context, req *types.Construct
 }
 
 func (b *Backend) ConstructionParse(ctx context.Context, req *types.ConstructionParseRequest) (*types.ConstructionParseResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+	rosettaTx, err := b.parsePayloadTxFromString(req.Transaction)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	hrp, err := mapper.GetHRP(req.NetworkIdentifier)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, "incorrect network identifier")
+	}
+
+	chainIDs := map[string]string{}
+	if rosettaTx.DestinationChainID != nil {
+		chainIDs[rosettaTx.DestinationChainID.String()] = rosettaTx.DestinationChain
+	}
+
+	txParser := cAtomicTxParser{
+		hrp:      hrp,
+		chainIDs: chainIDs,
+	}
+
+	return common.Parse(txParser, rosettaTx, req.Signed)
+}
+
+func (b *Backend) parsePayloadTxFromString(transaction string) (*common.RosettaTx, error) {
+	// Unmarshal input transaction
+	payloadsTx := &common.RosettaTx{
+		Tx: &cAtomicTx{
+			Codec:        b.codec,
+			CodecVersion: b.codecVersion,
+		},
+	}
+
+	err := json.Unmarshal([]byte(transaction), payloadsTx)
+	if err != nil {
+		return nil, errUndecodableTx
+	}
+
+	if payloadsTx.Tx == nil {
+		return nil, errNoTxGiven
+	}
+
+	return payloadsTx, nil
 }
 
 func (b *Backend) ConstructionCombine(ctx context.Context, req *types.ConstructionCombineRequest) (*types.ConstructionCombineResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+	rosettaTx, err := b.parsePayloadTxFromString(req.UnsignedTransaction)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	return common.Combine(b, rosettaTx, req.Signatures)
+}
+
+func (b *Backend) CombineTx(tx common.AvaxTx, signatures []*types.Signature) (common.AvaxTx, *types.Error) {
+	cTx, ok := tx.(*cAtomicTx)
+	if !ok {
+		return nil, service.WrapError(service.ErrInvalidInput, "invalid transaction")
+	}
+
+	creds, err := getTxCreds(cTx.Tx.UnsignedAtomicTx, signatures)
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, "unable attach signatures to transaction")
+	}
+
+	unsignedBytes, err := cTx.Marshal()
+	if err != nil {
+		return nil, service.WrapError(service.ErrInvalidInput, "unable to encode unsigned transaction")
+	}
+
+	cTx.Tx.Creds = creds
+
+	signedBytes, err := cTx.Marshal()
+	if err != nil {
+		return nil, service.WrapError(service.ErrInternalError, "unable to marshal signed transaction")
+	}
+
+	cTx.Tx.Initialize(unsignedBytes, signedBytes)
+
+	return cTx, nil
+}
+
+// getTxCreds fetches credentials based on the tx type
+func getTxCreds(
+	unsignedAtomicTx evm.UnsignedAtomicTx,
+	signatures []*types.Signature,
+) ([]verify.Verifiable, error) {
+	switch uat := unsignedAtomicTx.(type) {
+	case *evm.UnsignedImportTx:
+		return common.BuildCredentialList(uat.ImportedInputs, signatures)
+	case *evm.UnsignedExportTx:
+		return common.BuildSingletonCredentialList(signatures)
+	}
+
+	return nil, errUnknownTxType
 }
 
 func (b *Backend) ConstructionHash(ctx context.Context, req *types.ConstructionHashRequest) (*types.TransactionIdentifierResponse, *types.Error) {

--- a/service/backend/cchainatomictx/construction.go
+++ b/service/backend/cchainatomictx/construction.go
@@ -194,7 +194,12 @@ func (b *Backend) calculateSuggestedFee(ctx context.Context, gasUsed *big.Int) (
 }
 
 func (b *Backend) ConstructionPayloads(ctx context.Context, req *types.ConstructionPayloadsRequest) (*types.ConstructionPayloadsResponse, *types.Error) {
-	return nil, service.ErrNotImplemented
+	builder := cAtomicTxBuilder{
+		avaxAssetID:  b.avaxAssetID,
+		codec:        b.codec,
+		codecVersion: b.codecVersion,
+	}
+	return common.BuildPayloads(builder, req)
 }
 
 func (b *Backend) ConstructionParse(ctx context.Context, req *types.ConstructionParseRequest) (*types.ConstructionParseResponse, *types.Error) {

--- a/service/backend/cchainatomictx/construction_test.go
+++ b/service/backend/cchainatomictx/construction_test.go
@@ -3,6 +3,8 @@ package cchainatomictx
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -14,6 +16,7 @@ import (
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 	mocks "github.com/ava-labs/avalanche-rosetta/mocks/client"
 	"github.com/ava-labs/avalanche-rosetta/service"
+	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
 )
 
 var (
@@ -33,6 +36,18 @@ var (
 
 	avaxAssetID, _ = ids.FromString("U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK")
 )
+
+func buildRosettaSignerJSON(coinIdentifiers []string, signers []*types.AccountIdentifier) string {
+	importSigners := []*common.Signer{}
+	for i, s := range signers {
+		importSigners = append(importSigners, &common.Signer{
+			CoinIdentifier:    coinIdentifiers[i],
+			AccountIdentifier: s,
+		})
+	}
+	bytes, _ := json.Marshal(importSigners)
+	return string(bytes)
+}
 
 func TestConstructionDerive(t *testing.T) {
 	backend := NewBackend(nil, ids.Empty)
@@ -100,6 +115,23 @@ func TestExportTxConstruction(t *testing.T) {
 		"nonce":                float64(nonce),
 	}
 
+	signers := []*types.AccountIdentifier{cAccountIdentifier}
+	exportSigners := buildRosettaSignerJSON([]string{""}, signers)
+
+	unsignedExportTx := "0x000000000001000000057fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d50000000000000000000000000000000000000000000000000000000000000000000000013158e80abd5a1e1aa716003c9db096792c37962100000000009896803d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa0000000000000030000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa000000070000000000944dd20000000000000000000000010000000176da56a4600f1ba6f40fc3735f71e3f06c31d7590000000024739402"
+	unsignedExportTxHash, _ := hex.DecodeString("75afdcba5bf36457ba9edd65b07f40dcd3111d3c98a53550025af931b7500a7b")
+
+	signingPayloads := []*types.SigningPayload{
+		{
+			AccountIdentifier: cAccountIdentifier,
+			Bytes:             unsignedExportTxHash,
+			SignatureType:     types.EcdsaRecovery,
+		},
+	}
+
+	wrappedTxFormat := `{"tx":"%s","signers":%s,"destination_chain":"%s","destination_chain_id":"%s"}`
+	wrappedUnsignedExportTx := fmt.Sprintf(wrappedTxFormat, unsignedExportTx, exportSigners, "P", pChainID.String())
+
 	ctx := context.Background()
 	clientMock := &mocks.Client{}
 	backend := NewBackend(clientMock, avaxAssetID)
@@ -141,7 +173,21 @@ func TestExportTxConstruction(t *testing.T) {
 		clientMock.AssertExpectations(t)
 	})
 
-	t.Run("payloads endpoint", func(t *testing.T) {})
+	t.Run("payloads endpoint", func(t *testing.T) {
+		req := &types.ConstructionPayloadsRequest{
+			NetworkIdentifier: networkIdentifier,
+			Metadata:          payloadsMetadata,
+			Operations:        exportOperations,
+		}
+
+		resp, apiErr := backend.ConstructionPayloads(ctx, req)
+
+		assert.Nil(t, apiErr)
+		assert.Equal(t, wrappedUnsignedExportTx, resp.UnsignedTransaction)
+		assert.Equal(t, signingPayloads, resp.Payloads)
+
+		clientMock.AssertExpectations(t)
+	})
 
 	t.Run("parse endpoint (unsigned)", func(t *testing.T) {})
 
@@ -211,6 +257,28 @@ func TestImportTxConstruction(t *testing.T) {
 		"source_chain_id": pChainID.String(),
 	}
 
+	unsignedImportTx := "0x000000000000000000057fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d500000000000000000000000000000000000000000000000000000000000000000000000288ae5dd070e6d74f16c26358cd4a8f43746d4d338b5b75b668741c6d95816af5000000023d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa000000050000000000e4e1c00000000100000000b9a824340e1b94f27500cdfcbf8eaa9d4ee5e57b2823cb8b158de17689916c74000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa0000000500000000004c4b400000000100000000000000013158e80abd5a1e1aa716003c9db096792c37962100000000012c7a123d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa00000000c67b0534"
+
+	unsignedImportTxHash, _ := hex.DecodeString("33f98143f7f061e262e0fabca57b7f0dc110a79073ed263fc900ebdd0c1fe6fc")
+
+	signingPayloads := []*types.SigningPayload{
+		{
+			AccountIdentifier: cAccountBech32Identifier,
+			Bytes:             unsignedImportTxHash,
+			SignatureType:     types.EcdsaRecovery,
+		},
+		{
+			AccountIdentifier: cAccountBech32Identifier,
+			Bytes:             unsignedImportTxHash,
+			SignatureType:     types.EcdsaRecovery,
+		},
+	}
+
+	signers := []*types.AccountIdentifier{cAccountBech32Identifier, cAccountBech32Identifier}
+	importSigners := buildRosettaSignerJSON([]string{coinID1, coinID2}, signers)
+
+	wrappedUnsignedImportTx := `{"tx":"` + unsignedImportTx + `","signers":` + importSigners + `}`
+
 	ctx := context.Background()
 	clientMock := &mocks.Client{}
 	backend := NewBackend(clientMock, avaxAssetID)
@@ -250,7 +318,21 @@ func TestImportTxConstruction(t *testing.T) {
 		clientMock.AssertExpectations(t)
 	})
 
-	t.Run("payloads endpoint", func(t *testing.T) {})
+	t.Run("payloads endpoint", func(t *testing.T) {
+		req := &types.ConstructionPayloadsRequest{
+			NetworkIdentifier: networkIdentifier,
+			Metadata:          payloadsMetadata,
+			Operations:        importOperations,
+		}
+
+		resp, apiErr := backend.ConstructionPayloads(ctx, req)
+
+		assert.Nil(t, apiErr)
+		assert.Equal(t, wrappedUnsignedImportTx, resp.UnsignedTransaction)
+		assert.Equal(t, signingPayloads, resp.Payloads)
+
+		clientMock.AssertExpectations(t)
+	})
 
 	t.Run("parse endpoint (unsigned)", func(t *testing.T) {})
 

--- a/service/backend/cchainatomictx/types.go
+++ b/service/backend/cchainatomictx/types.go
@@ -1,6 +1,8 @@
 package cchainatomictx
 
 import (
+	"errors"
+
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/hashing"
@@ -82,4 +84,18 @@ func (c cAtomicTxBuilder) BuildTx(operations []*types.Operation, metadata map[st
 		Codec:        c.codec,
 		CodecVersion: c.codecVersion,
 	}, signers, nil
+}
+
+type cAtomicTxParser struct {
+	hrp      string
+	chainIDs map[string]string
+}
+
+func (c cAtomicTxParser) ParseTx(tx *common.RosettaTx, inputAddresses map[string]*types.AccountIdentifier) ([]*types.Operation, error) {
+	cTx, ok := tx.Tx.(*cAtomicTx)
+	if !ok {
+		return nil, errors.New("invalid transaction")
+	}
+	parser := cmapper.NewTxParser(c.hrp, c.chainIDs, inputAddresses)
+	return parser.Parse(*cTx.Tx)
 }

--- a/service/backend/cchainatomictx/types.go
+++ b/service/backend/cchainatomictx/types.go
@@ -1,0 +1,85 @@
+package cchainatomictx
+
+import (
+	"github.com/ava-labs/avalanchego/codec"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/hashing"
+	"github.com/ava-labs/coreth/plugin/evm"
+	"github.com/coinbase/rosetta-sdk-go/types"
+
+	"github.com/ava-labs/avalanche-rosetta/mapper"
+	cmapper "github.com/ava-labs/avalanche-rosetta/mapper/cchainatomictx"
+	"github.com/ava-labs/avalanche-rosetta/service"
+	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
+)
+
+type cAtomicTx struct {
+	Tx           *evm.Tx
+	Codec        codec.Manager
+	CodecVersion uint16
+}
+
+func (c *cAtomicTx) Marshal() ([]byte, error) {
+	return c.Codec.Marshal(c.CodecVersion, c.Tx)
+}
+
+func (c *cAtomicTx) Unmarshal(bytes []byte) error {
+	tx := evm.Tx{}
+	_, err := c.Codec.Unmarshal(bytes, &tx)
+	if err != nil {
+		return err
+	}
+	c.Tx = &tx
+	return nil
+}
+
+func (c *cAtomicTx) SigningPayload() ([]byte, error) {
+	unsignedAtomicBytes, err := c.Codec.Marshal(c.CodecVersion, &c.Tx.UnsignedAtomicTx)
+	if err != nil {
+		return nil, err
+	}
+
+	hash := hashing.ComputeHash256(unsignedAtomicBytes)
+	return hash, nil
+}
+
+func (c *cAtomicTx) Hash() ([]byte, error) {
+	bytes, err := c.Codec.Marshal(c.CodecVersion, &c.Tx)
+	if err != nil {
+		return nil, err
+	}
+
+	hash := hashing.ComputeHash256(bytes)
+	return hash, nil
+}
+
+type cAtomicTxBuilder struct {
+	avaxAssetID  ids.ID
+	codec        codec.Manager
+	codecVersion uint16
+}
+
+func (c cAtomicTxBuilder) BuildTx(operations []*types.Operation, metadata map[string]interface{}) (common.AvaxTx, []*types.AccountIdentifier, *types.Error) {
+	cMetadata := cmapper.Metadata{}
+	err := mapper.UnmarshalJSONMap(metadata, &cMetadata)
+	if err != nil {
+		return nil, nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	matches, err := common.MatchOperations(operations)
+	if err != nil {
+		return nil, nil, service.WrapError(service.ErrInvalidInput, err)
+	}
+
+	opType := matches[0].Operations[0].Type
+	tx, signers, err := cmapper.BuildTx(opType, matches, cMetadata, c.codec, c.avaxAssetID)
+	if err != nil {
+		return nil, nil, service.WrapError(service.ErrInternalError, err)
+	}
+
+	return &cAtomicTx{
+		Tx:           tx,
+		Codec:        c.codec,
+		CodecVersion: c.codecVersion,
+	}, signers, nil
+}

--- a/service/backend/common/construction.go
+++ b/service/backend/common/construction.go
@@ -275,6 +275,16 @@ func BuildCredentialList(ins []*avax.TransferableInput, signatures []*types.Sign
 	return creds, nil
 }
 
+func BuildSingletonCredentialList(signatures []*types.Signature) ([]verify.Verifiable, error) {
+	offset := 0
+	cred, err := buildCredential(1, &offset, signatures)
+	if err != nil {
+		return nil, err
+	}
+
+	return []verify.Verifiable{cred}, nil
+}
+
 func buildCredential(numSigs int, sigOffset *int, signatures []*types.Signature) (*secp256k1fx.Credential, error) {
 	cred := &secp256k1fx.Credential{}
 	cred.Sigs = make([][crypto.SECP256K1RSigLen]byte, numSigs)


### PR DESCRIPTION
Implementations for :

/construction/payloads
/construction/parse
/construction/combine
/construction/hash
/construction/submit
Using a single PR due to small amount of changes and their interdependencies to save back and forth time.