### PR TITLE
Add cross chain operations to transaction metadata

### DIFF
--- a/mapper/pchain/tx_parser.go
+++ b/mapper/pchain/tx_parser.go
@@ -111,19 +111,24 @@ func (t *TxParser) Parse(txID ids.ID, tx txs.UnsignedTx) (*types.Transaction, er
 		MetadataTxType: txType,
 	}
 
-	if ops.ImportIns != nil {
-		txMetadata[mapper.MetadataImportedInputs] = ops.ImportIns
-	}
+	var operations []*types.Operation
+	if ops != nil {
+		if ops.ImportIns != nil {
+			txMetadata[mapper.MetadataImportedInputs] = ops.ImportIns
+		}
 
-	if ops.ExportOuts != nil {
-		txMetadata[MetadataExportOuts] = ops.ExportOuts
+		if ops.ExportOuts != nil {
+			txMetadata[mapper.MetadataExportedOutputs] = ops.ExportOuts
+		}
+
+		operations = ops.IncludedOperations()
 	}
 
 	return &types.Transaction{
 		TransactionIdentifier: &types.TransactionIdentifier{
 			Hash: txID.String(),
 		},
-		Operations: ops.IncludedOperations(),
+		Operations: operations,
 		Metadata:   txMetadata,
 	}, nil
 }

--- a/mapper/pchain/tx_parser_test.go
+++ b/mapper/pchain/tx_parser_test.go
@@ -28,10 +28,13 @@ func TestMapInOperation(t *testing.T) {
 
 	avaxIn := addValidatorTx.Ins[0]
 	parser := NewTxParser(false, constants.FujiHRP, chainIDs, inputAccounts, nil)
-	rosettaInOp, err := parser.insToOperations(9, OpAddValidator, []*avax.TransferableInput{avaxIn}, OpTypeInput)
+	inOps := newTxOps(false)
+	err := parser.insToOperations(inOps, OpAddValidator, []*avax.TransferableInput{avaxIn}, OpTypeInput)
 	assert.Nil(t, err)
 
-	assert.Equal(t, int64(9), rosettaInOp[0].OperationIdentifier.Index)
+	rosettaInOp := inOps.Ins
+
+	assert.Equal(t, int64(0), rosettaInOp[0].OperationIdentifier.Index)
 	assert.Equal(t, OpAddValidator, rosettaInOp[0].Type)
 	assert.Equal(t, avaxIn.UTXOID.String(), rosettaInOp[0].CoinChange.CoinIdentifier.Identifier)
 	assert.Equal(t, types.CoinSpent, rosettaInOp[0].CoinChange.CoinAction)
@@ -52,8 +55,11 @@ func TestMapOutOperation(t *testing.T) {
 	avaxOut := addDelegatorTx.Outs[0]
 
 	parser := NewTxParser(true, constants.FujiHRP, chainIDs, inputAccounts, nil)
-	rosettaOutOp, err := parser.outsToOperations(0, 0, OpAddDelegator, ids.Empty, []*avax.TransferableOutput{avaxOut}, OpTypeOutput, mapper.PChainNetworkIdentifier)
+	outOps := newTxOps(false)
+	err := parser.outsToOperations(outOps, OpAddDelegator, ids.Empty, []*avax.TransferableOutput{avaxOut}, OpTypeOutput, mapper.PChainNetworkIdentifier)
 	assert.Nil(t, err)
+
+	rosettaOutOp := outOps.Outs
 
 	assert.Equal(t, int64(0), rosettaOutOp[0].OperationIdentifier.Index)
 	assert.Equal(t, "P-fuji1gdkq8g208e3j4epyjmx65jglsw7vauh86l47ac", rosettaOutOp[0].Account.Address)
@@ -154,6 +160,44 @@ func TestMapImportTx(t *testing.T) {
 	assert.Nil(t, rosettaTransaction.Operations[1].CoinChange)
 }
 
+func TestMapNonConstructionImportTx(t *testing.T) {
+	importTx, inputAccounts := buildImport()
+
+	assert.Equal(t, 0, len(importTx.Ins))
+	assert.Equal(t, 3, len(importTx.Outs))
+	assert.Equal(t, 1, len(importTx.ImportedInputs))
+
+	parser := NewTxParser(false, constants.FujiHRP, chainIDs, inputAccounts, nil)
+	rosettaTransaction, err := parser.Parse(ids.Empty, importTx)
+	assert.Nil(t, err)
+
+	total := len(importTx.Ins) + len(importTx.Outs) + len(importTx.ImportedInputs) - 3 // - 1 for the multisig output
+	assert.Equal(t, total, len(rosettaTransaction.Operations))
+
+	cntTxType, cntInputMeta, cntOutputMeta, cntMetaType := verifyRosettaTransaction(rosettaTransaction.Operations, OpImportAvax, OpTypeImport)
+
+	assert.Equal(t, 1, cntTxType)
+	assert.Equal(t, 0, cntInputMeta)
+	assert.Equal(t, 1, cntOutputMeta)
+	assert.Equal(t, 0, cntMetaType)
+
+	assert.Equal(t, types.CoinCreated, rosettaTransaction.Operations[0].CoinChange.CoinAction)
+
+	// Verify that export output are properly generated
+	importInputs, ok := rosettaTransaction.Metadata[MetadataImportIns].([]*types.Operation)
+	assert.True(t, ok)
+
+	// setting isConstruction to true in order to include imported input in the operations
+	parser = NewTxParser(true, constants.FujiHRP, chainIDs, inputAccounts, nil)
+	rosettaTransactionWithImportOperations, err := parser.Parse(ids.Empty, importTx)
+	assert.Nil(t, err)
+
+	inOp := rosettaTransactionWithImportOperations.Operations[0]
+	inOp.Status = types.String(mapper.StatusSuccess)
+	inOp.OperationIdentifier = nil
+	assert.Equal(t, []*types.Operation{inOp}, importInputs)
+}
+
 func TestMapExportTx(t *testing.T) {
 	exportTx, inputAccounts := buildExport()
 
@@ -174,6 +218,47 @@ func TestMapExportTx(t *testing.T) {
 	assert.Equal(t, 1, cntInputMeta)
 	assert.Equal(t, 1, cntOutputMeta)
 	assert.Equal(t, 1, cntMetaType)
+}
+
+func TestMapNonConstructionExportTx(t *testing.T) {
+	exportTx, inputAccounts := buildExport()
+
+	assert.Equal(t, 1, len(exportTx.Ins))
+	assert.Equal(t, 1, len(exportTx.Outs))
+	assert.Equal(t, 1, len(exportTx.ExportedOutputs))
+
+	parser := NewTxParser(false, constants.FujiHRP, chainIDs, inputAccounts, nil)
+	rosettaTransaction, err := parser.Parse(ids.Empty, exportTx)
+	assert.Nil(t, err)
+
+	total := len(exportTx.Ins) + len(exportTx.Outs)
+	assert.Equal(t, total, len(rosettaTransaction.Operations))
+
+	cntTxType, cntInputMeta, cntOutputMeta, cntMetaType := verifyRosettaTransaction(rosettaTransaction.Operations, OpExportAvax, OpTypeExport)
+
+	assert.Equal(t, 2, cntTxType)
+	assert.Equal(t, 1, cntInputMeta)
+	assert.Equal(t, 1, cntOutputMeta)
+	assert.Equal(t, 0, cntMetaType)
+
+	txType, ok := rosettaTransaction.Metadata[MetadataTxType].(string)
+	assert.True(t, ok)
+	assert.Equal(t, OpExportAvax, txType)
+
+	// Verify that export output are properly generated
+	exportOutputs, ok := rosettaTransaction.Metadata[MetadataExportOuts].([]*types.Operation)
+	assert.True(t, ok)
+
+	// setting isConstruction to true in order to include exported output in the operations
+	parser = NewTxParser(true, constants.FujiHRP, chainIDs, inputAccounts, nil)
+	rosettaTransactionWithExportOperations, err := parser.Parse(ids.Empty, exportTx)
+	assert.Nil(t, err)
+
+	out := rosettaTransactionWithExportOperations.Operations[2]
+	out.Status = types.String(mapper.StatusSuccess)
+	out.CoinChange = exportOutputs[0].CoinChange
+	out.OperationIdentifier = nil
+	assert.Equal(t, []*types.Operation{out}, exportOutputs)
 }
 
 func verifyRosettaTransaction(operations []*types.Operation, txType string, metaType string) (int, int, int, int) {

--- a/mapper/pchain/tx_parser_test.go
+++ b/mapper/pchain/tx_parser_test.go
@@ -184,7 +184,7 @@ func TestMapNonConstructionImportTx(t *testing.T) {
 	assert.Equal(t, types.CoinCreated, rosettaTransaction.Operations[0].CoinChange.CoinAction)
 
 	// Verify that export output are properly generated
-	importInputs, ok := rosettaTransaction.Metadata[MetadataImportIns].([]*types.Operation)
+	importInputs, ok := rosettaTransaction.Metadata[mapper.MetadataImportedInputs].([]*types.Operation)
 	assert.True(t, ok)
 
 	// setting isConstruction to true in order to include imported input in the operations
@@ -246,7 +246,7 @@ func TestMapNonConstructionExportTx(t *testing.T) {
 	assert.Equal(t, OpExportAvax, txType)
 
 	// Verify that export output are properly generated
-	exportOutputs, ok := rosettaTransaction.Metadata[MetadataExportOuts].([]*types.Operation)
+	exportOutputs, ok := rosettaTransaction.Metadata[mapper.MetadataExportedOutputs].([]*types.Operation)
 	assert.True(t, ok)
 
 	// setting isConstruction to true in order to include exported output in the operations

--- a/mapper/pchain/types.go
+++ b/mapper/pchain/types.go
@@ -35,8 +35,6 @@ const (
 	MetadataStakingStartTime = "staking_start_time"
 	MetadataStakingEndTime   = "staking_end_time"
 	MetadataMessage          = "message"
-	MetadataImportIns        = "imported_inputs"
-	MetadataExportOuts       = "exported_outputs"
 
 	SubAccountTypeSharedMemory       = "shared_memory"
 	SubAccountTypeUnlocked           = "unlocked"

--- a/mapper/pchain/types.go
+++ b/mapper/pchain/types.go
@@ -27,7 +27,6 @@ const (
 	OpTypeOutput      = "OUTPUT"
 	OpTypeStakeOutput = "STAKE"
 	OpTypeReward      = "REWARD"
-	OpTypeCreateChain = "CREATE_CHAIN"
 
 	MetadataOpType           = "type"
 	MetadataTxType           = "tx_type"
@@ -36,6 +35,8 @@ const (
 	MetadataStakingStartTime = "staking_start_time"
 	MetadataStakingEndTime   = "staking_end_time"
 	MetadataMessage          = "message"
+	MetadataImportIns        = "imported_inputs"
+	MetadataExportOuts       = "exported_outputs"
 
 	SubAccountTypeSharedMemory       = "shared_memory"
 	SubAccountTypeUnlocked           = "unlocked"

--- a/mapper/types.go
+++ b/mapper/types.go
@@ -46,8 +46,10 @@ const (
 	StatusSuccess = "SUCCESS"
 	StatusFailure = "FAILURE"
 
-	MetaAddressFormat   = "address_format"
-	AddressFormatBech32 = "bech32"
+	MetadataImportedInputs  = "imported_inputs"
+	MetadataExportedOutputs = "exported_outputs"
+	MetadataAddressFormat   = "address_format"
+	AddressFormatBech32     = "bech32"
 )
 
 var (

--- a/service/backend/cchainatomictx/backend.go
+++ b/service/backend/cchainatomictx/backend.go
@@ -45,7 +45,7 @@ func (b *Backend) ShouldHandleRequest(req interface{}) bool {
 	case *types.AccountCoinsRequest:
 		return cmapper.IsCChainBech32Address(r.AccountIdentifier)
 	case *types.ConstructionDeriveRequest:
-		return r.Metadata[mapper.MetaAddressFormat] == mapper.AddressFormatBech32
+		return r.Metadata[mapper.MetadataAddressFormat] == mapper.AddressFormatBech32
 	case *types.ConstructionMetadataRequest:
 		return r.Options[cmapper.MetadataAtomicTxGas] != nil
 	case *types.ConstructionPreprocessRequest:

--- a/service/backend/cchainatomictx/backend_test.go
+++ b/service/backend/cchainatomictx/backend_test.go
@@ -50,7 +50,7 @@ func TestShouldHandleRequest(t *testing.T) {
 		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionDeriveRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			Metadata: map[string]interface{}{
-				mapper.MetaAddressFormat: mapper.AddressFormatBech32,
+				mapper.MetadataAddressFormat: mapper.AddressFormatBech32,
 			},
 		}))
 		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionMetadataRequest{


### PR DESCRIPTION
Adding cross chain operation details to transaction metadata instead of silently excluding them from the operations. This is useful when identifying the importable UTXOs.