### PR TITLE
Fixing AdvanceTimeTx lookup and multisig check regression 

### DIFF
--- a/mapper/pchain/tx_parser.go
+++ b/mapper/pchain/tx_parser.go
@@ -20,7 +20,6 @@ import (
 var (
 	errUnknownDestinationChain  = errors.New("unknown destination chain")
 	errNoDependencyTxs          = errors.New("no dependency txs provided")
-	errUnknownDependencyTx      = errors.New("unknown dependency tx type")
 	errNoMatchingRewardOutputs  = errors.New("no matching reward outputs")
 	errNoMatchingInputAddresses = errors.New("no matching input addresses")
 	errNoOutputAddresses        = errors.New("no output addresses")
@@ -622,8 +621,10 @@ func GetDependencyTxIDs(tx txs.UnsignedTx) ([]ids.ID, error) {
 		txIds = append(txIds, getUniqueTxIds(unsignedTx.Ins)...)
 	case *txs.RewardValidatorTx:
 		txIds = append(txIds, unsignedTx.TxID)
+	case *txs.AdvanceTimeTx:
+		// advance time txs do not have inputs
 	default:
-		return nil, errUnknownDependencyTx
+		log.Printf("unknown type %T", unsignedTx)
 	}
 
 	ids.SortIDs(txIds)

--- a/mapper/pchain/tx_parser.go
+++ b/mapper/pchain/tx_parser.go
@@ -333,22 +333,30 @@ func (t *TxParser) insToOperations(
 			return err
 		}
 
-		// If dependency txs are provided, which is the case for /block endpoints
-		// check whether the input UTXO is multisig. If so, skip it.
-		if t.dependencyTxs != nil {
-			isMultisig, err := t.isMultisig(in.UTXOID)
-			if err != nil {
-				return errFailedToCheckMultisig
-			}
-			if isMultisig {
-				continue
-			}
-		}
-
 		utxoID := in.UTXOID.String()
-		account, ok := t.inputTxAccounts[utxoID]
-		if !ok {
-			return errNoMatchingInputAddresses
+
+		var account *types.AccountIdentifier
+
+		// Check if the dependency is not multisig and extract account id from it
+		// for non-imported inputs or when tx is being constructed
+		if t.isConstruction || metaType != OpTypeImport {
+			// If dependency txs are provided, which is the case for /block endpoints
+			// check whether the input UTXO is multisig. If so, skip it.
+			if t.dependencyTxs != nil {
+				isMultisig, err := t.isMultisig(in.UTXOID)
+				if err != nil {
+					return errFailedToCheckMultisig
+				}
+				if isMultisig {
+					continue
+				}
+			}
+
+			var ok bool
+			account, ok = t.inputTxAccounts[utxoID]
+			if !ok {
+				return errNoMatchingInputAddresses
+			}
 		}
 
 		inputAmount := new(big.Int).SetUint64(in.In.Amount())


### PR DESCRIPTION
Fixes 2 bugs:
- AdvanceTimeTx dependency lookup error
- Block lookup regression related to multisig checks for the imported_inputs/exported_outputs
