### PR TITLE
Multiple updates

### DIFF
--- a/client/pchainclient.go
+++ b/client/pchainclient.go
@@ -17,6 +17,9 @@ import (
 // Interface compliance
 var _ PChainClient = &pchainClient{}
 
+// PChainClient contains all client methods used to interact with avalanchego in order to support P-chain operations in Rosetta.
+//
+// These methods are cloned from the underlying avalanchego client interfaces, following the example of Client interface used to support C-chain operations.
 type PChainClient interface {
 	// indexer.Client methods
 	GetContainerByIndex(ctx context.Context, index uint64, options ...rpc.Option) (indexer.Container, error)

--- a/mapper/amount.go
+++ b/mapper/amount.go
@@ -22,6 +22,7 @@ func AvaxAmount(value *big.Int) *types.Amount {
 	return Amount(value, AvaxCurrency)
 }
 
+// AtomicAvaxAmount creates a Rosetta Amount representing AVAX amount in nAVAXs with given quantity
 func AtomicAvaxAmount(value *big.Int) *types.Amount {
 	return Amount(value, AtomicAvaxCurrency)
 }

--- a/mapper/cchainatomictx/helper.go
+++ b/mapper/cchainatomictx/helper.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 )
 
+// IsCChainBech32Address checks whether a given account identifier contains a C-chain Bech32 type address
 func IsCChainBech32Address(accountIdentifier *types.AccountIdentifier) bool {
 	if chainID, _, _, err := address.Parse(accountIdentifier.Address); err == nil {
 		return chainID == mapper.CChainNetworkIdentifier
@@ -14,6 +15,7 @@ func IsCChainBech32Address(accountIdentifier *types.AccountIdentifier) bool {
 	return false
 }
 
+// IsAtomicOpType determines whether a given C-chain operation is an atomic one
 func IsAtomicOpType(t string) bool {
 	return t == mapper.OpExport || t == mapper.OpImport
 }

--- a/mapper/cchainatomictx/tx_builder.go
+++ b/mapper/cchainatomictx/tx_builder.go
@@ -20,6 +20,8 @@ import (
 
 var errMissingCoinIdentifier = errors.New("input operation does not have coin identifier")
 
+// BuildTx constructs an evm tx based on the provided operation type, Rosetta matches and metadata
+// This method is only used during construction.
 func BuildTx(opType string, matches []*parser.Match, metadata Metadata, codec codec.Manager, avaxAssetID ids.ID) (*evm.Tx, []*types.AccountIdentifier, error) {
 	switch opType {
 	case mapper.OpExport:

--- a/mapper/cchainatomictx/tx_parser.go
+++ b/mapper/cchainatomictx/tx_parser.go
@@ -20,16 +20,23 @@ var (
 	errNoMatchingInputAddresses = errors.New("no matching input addresses")
 )
 
+// TxParser parses C-chain atomic transactions and generate corresponding Rosetta operations
 type TxParser struct {
-	hrp             string
-	chainIDs        map[string]string
+	// hrp used for address formatting
+	hrp string
+	// chainIDs contain chain id to chain id alias mappings
+	chainIDs map[string]string
+	// inputTxAccounts contain utxo id to account identifier mappings
 	inputTxAccounts map[string]*types.AccountIdentifier
 }
 
+// NewTxParser returns a new transaction parser
 func NewTxParser(hrp string, chainIDs map[string]string, inputTxAccounts map[string]*types.AccountIdentifier) *TxParser {
 	return &TxParser{hrp: hrp, chainIDs: chainIDs, inputTxAccounts: inputTxAccounts}
 }
 
+// Parse converts the given atomic evm tx to corresponding Rosetta operations
+// This method is only used during construction.
 func (t *TxParser) Parse(tx evm.Tx) ([]*types.Operation, error) {
 	switch unsignedTx := tx.UnsignedAtomicTx.(type) {
 	case *evm.UnsignedExportTx:

--- a/mapper/cchainatomictx/types.go
+++ b/mapper/cchainatomictx/types.go
@@ -12,6 +12,7 @@ const (
 	MetadataSourceChain = "source_chain"
 )
 
+// Metadata contains metadata values returned by /construction/metadata for C-chain atomic transactions
 type Metadata struct {
 	NetworkID          uint32  `json:"network_id,omitempty"`
 	CChainID           ids.ID  `json:"c_chain_id,omitempty"`
@@ -21,6 +22,7 @@ type Metadata struct {
 	Nonce              uint64  `json:"nonce"`
 }
 
+// Options contains response values returned by /construction/preprocess for C-chain atomic transactions
 type Options struct {
 	AtomicTxGas      *big.Int `json:"atomic_tx_gas"`
 	From             string   `json:"from,omitempty"`

--- a/mapper/helper.go
+++ b/mapper/helper.go
@@ -66,7 +66,7 @@ func MarshalJSONMap(i interface{}) (map[string]interface{}, error) {
 	return m, nil
 }
 
-// Parse string into avax.UTXOID
+// DecodeUTXOID decodes given string into avax.UTXOID
 func DecodeUTXOID(s string) (*avax.UTXOID, error) {
 	split := strings.Split(s, ":")
 	if len(split) != 2 {
@@ -89,10 +89,12 @@ func DecodeUTXOID(s string) (*avax.UTXOID, error) {
 	}, nil
 }
 
+// EncodeBytes encodes given bytes to string
 func EncodeBytes(bytes []byte) (string, error) {
 	return formatting.Encode(formatting.Hex, bytes)
 }
 
+// DecodeToBytes decodes given string into bytes using the same encoding as EncodeBytes
 func DecodeToBytes(binaryData string) ([]byte, error) {
 	return formatting.Decode(formatting.Hex, binaryData)
 }

--- a/mapper/pchain/tx_builder.go
+++ b/mapper/pchain/tx_builder.go
@@ -23,6 +23,8 @@ var (
 	errOutputAmountOverflow = errors.New("sum of output amounts caused overflow")
 )
 
+// BuildTx constructs a P-chain Tx based on the provided operation type, Rosetta matches and metadata
+// This method is only used during construction.
 func BuildTx(
 	opType string,
 	matches []*parser.Match,
@@ -319,6 +321,7 @@ func buildInputs(
 	return ins, imported, signers, nil
 }
 
+// ParseOpMetadata creates an OperationMetadata from given generic metadata map
 func ParseOpMetadata(metadata map[string]interface{}) (*OperationMetadata, error) {
 	var operationMetadata OperationMetadata
 	if err := mapper.UnmarshalJSONMap(metadata, &operationMetadata); err != nil {

--- a/mapper/pchain/tx_parser.go
+++ b/mapper/pchain/tx_parser.go
@@ -1,7 +1,9 @@
 package pchain
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"log"
 	"math/big"
 
@@ -14,10 +16,12 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/coinbase/rosetta-sdk-go/types"
 
+	"github.com/ava-labs/avalanche-rosetta/client"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 )
 
 var (
+	errNilPChainClient                = errors.New("pchain client can only be nil during construction")
 	errNilChainIDs                    = errors.New("chain ids cannot be nil")
 	errNilInputTxAccounts             = errors.New("input tx accounts cannot be nil")
 	errUnknownDestinationChain        = errors.New("unknown destination chain")
@@ -29,6 +33,7 @@ var (
 	errFailedToCheckMultisig          = errors.New("failed to check utxo for multisig")
 	errOutputTypeAssertion            = errors.New("output type assertion failed")
 	errUnknownRewardSourceTransaction = errors.New("unknown source tx type for reward tx")
+	errUnsupportedAssetInConstruction = errors.New("unsupported asset passed during construction")
 )
 
 // TxParser parses P-chain transactions and generate corresponding Rosetta operations
@@ -43,6 +48,10 @@ type TxParser struct {
 	dependencyTxs map[string]*DependencyTx
 	// inputTxAccounts contain utxo id to account identifier mappings
 	inputTxAccounts map[string]*types.AccountIdentifier
+	// pChainClient holds a P-chain client, used to lookup asset descriptions for non-AVAX assets
+	pChainClient client.PChainClient
+	// avaxAssetID contains asset id for AVAX currency
+	avaxAssetID ids.ID
 }
 
 // NewTxParser returns a new transaction parser
@@ -52,6 +61,8 @@ func NewTxParser(
 	chainIDs map[string]string,
 	inputTxAccounts map[string]*types.AccountIdentifier,
 	dependencyTxs map[string]*DependencyTx,
+	pChainClient client.PChainClient,
+	avaxAssetID ids.ID,
 ) (*TxParser, error) {
 	if chainIDs == nil {
 		return nil, errNilChainIDs
@@ -61,12 +72,18 @@ func NewTxParser(
 		return nil, errNilInputTxAccounts
 	}
 
+	if !isConstruction && pChainClient == nil {
+		return nil, errNilPChainClient
+	}
+
 	return &TxParser{
 		isConstruction:  isConstruction,
 		hrp:             hrp,
 		chainIDs:        chainIDs,
 		inputTxAccounts: inputTxAccounts,
 		dependencyTxs:   dependencyTxs,
+		pChainClient:    pChainClient,
+		avaxAssetID:     avaxAssetID,
 	}, nil
 }
 
@@ -405,7 +422,15 @@ func (t *TxParser) insToOperations(
 			}
 		}
 
-		inputAmount := new(big.Int).SetUint64(in.In.Amount())
+		bigAmount := new(big.Int).SetUint64(in.In.Amount())
+		// Negating input amount
+		inputAmount := new(big.Int).Neg(bigAmount)
+
+		amount, err := t.buildAmount(inputAmount, in.AssetID())
+		if err != nil {
+			return err
+		}
+
 		inOp := &types.Operation{
 			OperationIdentifier: &types.OperationIdentifier{
 				Index: int64(inOps.Len()),
@@ -413,8 +438,7 @@ func (t *TxParser) insToOperations(
 			Type:    opType,
 			Status:  status,
 			Account: account,
-			// Negating input amount
-			Amount: mapper.AtomicAvaxAmount(new(big.Int).Neg(inputAmount)),
+			Amount:  amount,
 			CoinChange: &types.CoinChange{
 				CoinIdentifier: &types.CoinIdentifier{
 					Identifier: utxoID,
@@ -427,6 +451,23 @@ func (t *TxParser) insToOperations(
 		inOps.Append(inOp, metaType)
 	}
 	return nil
+}
+
+func (t *TxParser) buildAmount(value *big.Int, assetID ids.ID) (*types.Amount, error) {
+	if assetID == t.avaxAssetID {
+		return mapper.AtomicAvaxAmount(value), nil
+	}
+
+	if t.isConstruction {
+		return nil, errUnsupportedAssetInConstruction
+	}
+
+	currency, err := t.lookupCurrency(assetID)
+	if err != nil {
+		return nil, err
+	}
+
+	return mapper.Amount(value, currency), nil
 }
 
 func (t *TxParser) outsToOperations(
@@ -469,6 +510,7 @@ func (t *TxParser) outsToOperations(
 
 		outOp, err := t.buildOutputOperation(
 			transferOutput,
+			out.AssetID(),
 			status,
 			outOps.Len(),
 			txID,
@@ -525,6 +567,7 @@ func (t *TxParser) utxosToOperations(
 
 		outOp, err := t.buildOutputOperation(
 			out,
+			utxo.AssetID(),
 			status,
 			outOps.Len(),
 			utxo.TxID,
@@ -545,6 +588,7 @@ func (t *TxParser) utxosToOperations(
 
 func (t *TxParser) buildOutputOperation(
 	out *secp256k1fx.TransferOutput,
+	assetID ids.ID,
 	status *string,
 	startIndex int,
 	txID ids.ID,
@@ -586,6 +630,11 @@ func (t *TxParser) buildOutputOperation(
 		}
 	}
 
+	amount, err := t.buildAmount(outBigAmount, assetID)
+	if err != nil {
+		return nil, err
+	}
+
 	return &types.Operation{
 		Type: opType,
 		OperationIdentifier: &types.OperationIdentifier{
@@ -594,7 +643,7 @@ func (t *TxParser) buildOutputOperation(
 		CoinChange: coinChange,
 		Status:     status,
 		Account:    &types.AccountIdentifier{Address: outAddrFormat},
-		Amount:     mapper.AtomicAvaxAmount(outBigAmount),
+		Amount:     amount,
 		Metadata:   opMetadata,
 	}, nil
 }
@@ -618,6 +667,18 @@ func (t *TxParser) isMultisig(utxoid avax.UTXOID) (bool, error) {
 	isMultisig := len(addressable.Addresses()) != 1
 
 	return isMultisig, nil
+}
+
+func (t *TxParser) lookupCurrency(assetID ids.ID) (*types.Currency, error) {
+	asset, err := t.pChainClient.GetAssetDescription(context.Background(), assetID.String())
+	if err != nil {
+		return nil, fmt.Errorf("error while looking up currency: %w", err)
+	}
+
+	return &types.Currency{
+		Symbol:   asset.Symbol,
+		Decimals: int32(asset.Denomination),
+	}, nil
 }
 
 // GetAccountsFromUTXOs extracts destination accounts from given dependency transactions

--- a/mapper/pchain/tx_parser.go
+++ b/mapper/pchain/tx_parser.go
@@ -31,14 +31,21 @@ var (
 	errUnknownRewardSourceTransaction = errors.New("unknown source tx type for reward tx")
 )
 
+// TxParser parses P-chain transactions and generate corresponding Rosetta operations
 type TxParser struct {
-	isConstruction  bool
-	hrp             string
-	chainIDs        map[string]string
-	dependencyTxs   map[string]*DependencyTx
+	// isConstruction indicates if parsing is done as part of construction or /block endpoints
+	isConstruction bool
+	// hrp used for address formatting
+	hrp string
+	// chainIDs contain chain id to chain id alias mappings
+	chainIDs map[string]string
+	// dependencyTxs contain transaction id to dependence transaction mapping
+	dependencyTxs map[string]*DependencyTx
+	// inputTxAccounts contain utxo id to account identifier mappings
 	inputTxAccounts map[string]*types.AccountIdentifier
 }
 
+// NewTxParser returns a new transaction parser
 func NewTxParser(
 	isConstruction bool,
 	hrp string,
@@ -63,6 +70,7 @@ func NewTxParser(
 	}, nil
 }
 
+// Parse converts the given unsigned P-chain tx to corresponding Rosetta Transaction
 func (t *TxParser) Parse(txID ids.ID, tx txs.UnsignedTx) (*types.Transaction, error) {
 	var (
 		ops    *txOps
@@ -598,6 +606,7 @@ func (t *TxParser) isMultisig(utxoid avax.UTXOID) (bool, error) {
 	return isMultisig, nil
 }
 
+// GetAccountsFromUTXOs extracts destination accounts from given dependency transactions
 func GetAccountsFromUTXOs(hrp string, dependencyTxs map[string]*DependencyTx) (map[string]*types.AccountIdentifier, error) {
 	addresses := make(map[string]*types.AccountIdentifier)
 	for _, dependencyTx := range dependencyTxs {
@@ -626,6 +635,9 @@ func GetAccountsFromUTXOs(hrp string, dependencyTxs map[string]*DependencyTx) (m
 	return addresses, nil
 }
 
+// GetDependencyTxIDs generates the list of transaction ids used in the inputs to given unsigned transaction
+// this list is then used to fetch the dependency transactions in order to extract source addresses
+// as this information is not part of the transaction objects on chain.
 func GetDependencyTxIDs(tx txs.UnsignedTx) ([]ids.ID, error) {
 	var txIds []ids.ID
 	switch unsignedTx := tx.(type) {

--- a/mapper/pchain/tx_parser_test.go
+++ b/mapper/pchain/tx_parser_test.go
@@ -190,7 +190,7 @@ func TestMapNonConstructionImportTx(t *testing.T) {
 
 	importedInput := importTx.ImportedInputs[0]
 	expectedImportedInputs := []*types.Operation{{
-		OperationIdentifier: nil,
+		OperationIdentifier: &types.OperationIdentifier{Index: 1},
 		Type:                OpImportAvax,
 		Status:              types.String(mapper.StatusSuccess),
 		Account:             nil,
@@ -267,7 +267,6 @@ func TestMapNonConstructionExportTx(t *testing.T) {
 	out := rosettaTransactionWithExportOperations.Operations[2]
 	out.Status = types.String(mapper.StatusSuccess)
 	out.CoinChange = exportOutputs[0].CoinChange
-	out.OperationIdentifier = nil
 	assert.Equal(t, []*types.Operation{out}, exportOutputs)
 }
 

--- a/mapper/pchain/types.go
+++ b/mapper/pchain/types.go
@@ -62,6 +62,7 @@ var (
 	CallMethods = []string{}
 )
 
+// OperationMetadata contains metadata fields specific to individual Rosetta operations as opposed to transactions
 type OperationMetadata struct {
 	Type       string   `json:"type"`
 	SigIndices []uint32 `json:"sig_indices,omitempty"`
@@ -69,11 +70,13 @@ type OperationMetadata struct {
 	Threshold  uint32   `json:"threshold,omitempty"`
 }
 
+// ImportExportOptions contain response fields returned by /construction/preprocess for P-chain Import/Export transactions
 type ImportExportOptions struct {
 	SourceChain      string `json:"source_chain"`
 	DestinationChain string `json:"destination_chain"`
 }
 
+// StakingOptions contain response fields returned by /construction/preprocess for P-chain AddValidator/AddDelegator transactions
 type StakingOptions struct {
 	NodeID          string   `json:"node_id"`
 	Start           uint64   `json:"start"`
@@ -85,6 +88,7 @@ type StakingOptions struct {
 	RewardAddresses []string `json:"reward_addresses"`
 }
 
+// Metadata contains metadata values returned by /construction/metadata for P-chain transactions
 type Metadata struct {
 	NetworkID    uint32 `json:"network_id"`
 	BlockchainID ids.ID `json:"blockchain_id"`
@@ -93,15 +97,18 @@ type Metadata struct {
 	*StakingMetadata
 }
 
+// ImportMetadata contain response fields returned by /construction/metadata for P-chain Import transactions
 type ImportMetadata struct {
 	SourceChainID ids.ID `json:"source_chain_id"`
 }
 
+// ExportMetadata contain response fields returned by /construction/metadata for P-chain Export transactions
 type ExportMetadata struct {
 	DestinationChain   string `json:"destination_chain"`
 	DestinationChainID ids.ID `json:"destination_chain_id"`
 }
 
+// StakingMetadata contain response fields returned by /construction/metadata for P-chain AddValidator/AddDelegator transactions
 type StakingMetadata struct {
 	NodeID          string   `json:"node_id"`
 	RewardAddresses []string `json:"reward_addresses"`
@@ -113,6 +120,7 @@ type StakingMetadata struct {
 	Memo            string   `json:"memo"`
 }
 
+// DependencyTx represents a transaction some of whose output is used as an input to another transaction
 type DependencyTx struct {
 	Tx          *txs.Tx
 	RewardUTXOs []*avax.UTXO

--- a/service/backend/cchainatomictx/account.go
+++ b/service/backend/cchainatomictx/account.go
@@ -20,6 +20,9 @@ var (
 	errUnableToGetUTXOOutput = errors.New("unable to get UTXO output")
 )
 
+// AccountBalance implements /account/balance endpoint for C-chain atomic transaction balance
+//
+// This endpoint is called if the account is in Bech32 format for a C-chain request
 func (b *Backend) AccountBalance(ctx context.Context, req *types.AccountBalanceRequest) (*types.AccountBalanceResponse, *types.Error) {
 	if req.AccountIdentifier == nil {
 		return nil, service.WrapError(service.ErrInvalidInput, "account identifier is not provided")
@@ -54,6 +57,9 @@ func (b *Backend) AccountBalance(ctx context.Context, req *types.AccountBalanceR
 	}, nil
 }
 
+// AccountCoins implements /account/coins endpoint for C-chain atomic transaction UTXOs
+//
+// This endpoint is called if the account is in Bech32 format for a C-chain request
 func (b *Backend) AccountCoins(ctx context.Context, req *types.AccountCoinsRequest) (*types.AccountCoinsResponse, *types.Error) {
 	if req.AccountIdentifier == nil {
 		return nil, service.WrapError(service.ErrInvalidInput, "account identifier is not provided")

--- a/service/backend/cchainatomictx/backend.go
+++ b/service/backend/cchainatomictx/backend.go
@@ -27,6 +27,7 @@ type Backend struct {
 	avaxAssetID      ids.ID
 }
 
+// NewBackend creates a C-chain atomic transaction service backend
 func NewBackend(cClient client.Client, avaxAssetID ids.ID) *Backend {
 	return &Backend{
 		fac:              &crypto.FactorySECP256K1R{},
@@ -38,6 +39,7 @@ func NewBackend(cClient client.Client, avaxAssetID ids.ID) *Backend {
 	}
 }
 
+// ShouldHandleRequest returns whether a given request should be handled by this backend
 func (b *Backend) ShouldHandleRequest(req interface{}) bool {
 	switch r := req.(type) {
 	case *types.AccountBalanceRequest:

--- a/service/backend/cchainatomictx/construction.go
+++ b/service/backend/cchainatomictx/construction.go
@@ -28,10 +28,12 @@ var (
 	errNoTxGiven     = errors.New("no transaction was given")
 )
 
+// ConstructionDerive implements /construction/derive endpoint for C-chain atomic transactions
 func (b *Backend) ConstructionDerive(ctx context.Context, req *types.ConstructionDeriveRequest) (*types.ConstructionDeriveResponse, *types.Error) {
 	return common.DeriveBech32Address(b.fac, mapper.CChainNetworkIdentifier, req)
 }
 
+// ConstructionPreprocess implements /construction/preprocess endpoint for C-chain atomic transactions
 func (b *Backend) ConstructionPreprocess(
 	ctx context.Context,
 	req *types.ConstructionPreprocessRequest,
@@ -119,6 +121,7 @@ func (b *Backend) estimateGasUsed(opType string, matches []*parser.Match) (uint6
 	return tx.GasUsed(true)
 }
 
+// ConstructionMetadata implements /construction/metadata endpoint for C-chain atomic transactions
 func (b *Backend) ConstructionMetadata(
 	ctx context.Context,
 	req *types.ConstructionMetadataRequest,
@@ -203,6 +206,7 @@ func (b *Backend) calculateSuggestedFee(ctx context.Context, gasUsed *big.Int) (
 	return mapper.AtomicAvaxAmount(suggestedFee), nil
 }
 
+// ConstructionPayloads implements /construction/payloads endpoint for C-chain atomic transactions
 func (b *Backend) ConstructionPayloads(ctx context.Context, req *types.ConstructionPayloadsRequest) (*types.ConstructionPayloadsResponse, *types.Error) {
 	builder := cAtomicTxBuilder{
 		avaxAssetID:  b.avaxAssetID,
@@ -212,6 +216,7 @@ func (b *Backend) ConstructionPayloads(ctx context.Context, req *types.Construct
 	return common.BuildPayloads(builder, req)
 }
 
+// ConstructionParse implements /construction/parse endpoint for C-chain atomic transactions
 func (b *Backend) ConstructionParse(ctx context.Context, req *types.ConstructionParseRequest) (*types.ConstructionParseResponse, *types.Error) {
 	rosettaTx, err := b.parsePayloadTxFromString(req.Transaction)
 	if err != nil {
@@ -257,6 +262,7 @@ func (b *Backend) parsePayloadTxFromString(transaction string) (*common.RosettaT
 	return payloadsTx, nil
 }
 
+// ConstructionCombine implements /construction/combine endpoint for C-chain atomic transactions
 func (b *Backend) ConstructionCombine(ctx context.Context, req *types.ConstructionCombineRequest) (*types.ConstructionCombineResponse, *types.Error) {
 	rosettaTx, err := b.parsePayloadTxFromString(req.UnsignedTransaction)
 	if err != nil {
@@ -266,6 +272,7 @@ func (b *Backend) ConstructionCombine(ctx context.Context, req *types.Constructi
 	return common.Combine(b, rosettaTx, req.Signatures)
 }
 
+// CombineTx implements C-chain atomic transaction specific logic for combining unsigned transactions and signatures
 func (b *Backend) CombineTx(tx common.AvaxTx, signatures []*types.Signature) (common.AvaxTx, *types.Error) {
 	cTx, ok := tx.(*cAtomicTx)
 	if !ok {
@@ -309,6 +316,7 @@ func getTxCreds(
 	return nil, errUnknownTxType
 }
 
+// ConstructionHash implements /construction/hash endpoint for C-chain atomic transactions
 func (b *Backend) ConstructionHash(
 	ctx context.Context,
 	req *types.ConstructionHashRequest,
@@ -321,6 +329,7 @@ func (b *Backend) ConstructionHash(
 	return common.HashTx(rosettaTx)
 }
 
+// ConstructionSubmit implements /construction/submit endpoint for C-chain atomic transactions
 func (b *Backend) ConstructionSubmit(
 	ctx context.Context,
 	req *types.ConstructionSubmitRequest,

--- a/service/backend/cchainatomictx/types.go
+++ b/service/backend/cchainatomictx/types.go
@@ -45,14 +45,19 @@ func (c *cAtomicTx) SigningPayload() ([]byte, error) {
 	return hash, nil
 }
 
-func (c *cAtomicTx) Hash() ([]byte, error) {
-	bytes, err := c.Codec.Marshal(c.CodecVersion, &c.Tx)
+func (c *cAtomicTx) Hash() (ids.ID, error) {
+	unsignedBytes, err := c.Codec.Marshal(c.CodecVersion, &c.Tx.UnsignedAtomicTx)
 	if err != nil {
-		return nil, err
+		return ids.Empty, err
 	}
 
-	hash := hashing.ComputeHash256(bytes)
-	return hash, nil
+	signedBytes, err := c.Codec.Marshal(c.CodecVersion, &c.Tx)
+	if err != nil {
+		return ids.Empty, err
+	}
+
+	c.Tx.Initialize(unsignedBytes, signedBytes)
+	return c.Tx.ID(), nil
 }
 
 type cAtomicTxBuilder struct {

--- a/service/backend/common/construction.go
+++ b/service/backend/common/construction.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/utils/cb58"
 	"github.com/ava-labs/avalanchego/utils/crypto"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
@@ -302,16 +301,14 @@ func buildCredential(numSigs int, sigOffset *int, signatures []*types.Signature)
 	return cred, nil
 }
 
+// Generates a transaction id for the given RosettaTx
 func HashTx(rosettaTx *RosettaTx) (*types.TransactionIdentifierResponse, *types.Error) {
-	txHashBytes, err := rosettaTx.Tx.Hash()
+	txID, err := rosettaTx.Tx.Hash()
 	if err != nil {
 		return nil, service.WrapError(service.ErrInvalidInput, err)
 	}
 
-	hash, err := cb58.Encode(txHashBytes)
-	if err != nil {
-		return nil, service.WrapError(service.ErrInvalidInput, err)
-	}
+	hash := txID.String()
 
 	return &types.TransactionIdentifierResponse{
 		TransactionIdentifier: &types.TransactionIdentifier{

--- a/service/backend/common/types.go
+++ b/service/backend/common/types.go
@@ -14,7 +14,7 @@ type AvaxTx interface {
 	Marshal() ([]byte, error)
 	Unmarshal([]byte) error
 	SigningPayload() ([]byte, error)
-	Hash() ([]byte, error)
+	Hash() (ids.ID, error)
 }
 
 type RosettaTx struct {

--- a/service/backend/common/types.go
+++ b/service/backend/common/types.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 )
 
+// AvaxTx encapsulates P-chain and C-chain atomic transactions in order to reuse common logic between them
 type AvaxTx interface {
 	Marshal() ([]byte, error)
 	Unmarshal([]byte) error
@@ -17,18 +18,17 @@ type AvaxTx interface {
 	Hash() (ids.ID, error)
 }
 
+// RosettaTx wraps a transaction along with the input addresses and destination chain information.
+// It is used during construction between /construction/payloads and /construction/parse since parse needs this information
+// but C-chain atomic and P-chain tx formats strip this information and only retain UTXO ids.
 type RosettaTx struct {
-	// The body of this transaction
-	Tx AvaxTx
-
-	// AccountIdentifierSigners used by /construction/parse
-
+	Tx                       AvaxTx
 	AccountIdentifierSigners []Signer
-
-	DestinationChain   string
-	DestinationChainID *ids.ID
+	DestinationChain         string
+	DestinationChainID       *ids.ID
 }
 
+// Signer contains details of coin identifiers and the accounts signing those coins
 type Signer struct {
 	CoinIdentifier    string                   `json:"coin_identifier,omitempty"`
 	AccountIdentifier *types.AccountIdentifier `json:"account_identifier"`
@@ -88,6 +88,7 @@ func (t *RosettaTx) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// GetAccountIdentifiers extracts input account identifiers from given Rosetta operations
 func (t *RosettaTx) GetAccountIdentifiers(operations []*types.Operation) ([]*types.AccountIdentifier, error) {
 	signers := []*types.AccountIdentifier{}
 

--- a/service/backend/pchain/account.go
+++ b/service/backend/pchain/account.go
@@ -34,6 +34,7 @@ var (
 	errUnlockedStakeableOverflow  = errors.New("overflow while calculating unlocked stakeable balance")
 )
 
+// AccountBalance implements /account/balance endpoint for P-chain
 func (b *Backend) AccountBalance(ctx context.Context, req *types.AccountBalanceRequest) (*types.AccountBalanceResponse, *types.Error) {
 	if req.AccountIdentifier == nil {
 		return nil, service.WrapError(service.ErrInvalidInput, "account identifier is not provided")
@@ -90,6 +91,7 @@ func (b *Backend) AccountBalance(ctx context.Context, req *types.AccountBalanceR
 	}, nil
 }
 
+// AccountCoins implements /account/coins endpoint for P-chain
 func (b *Backend) AccountCoins(ctx context.Context, req *types.AccountCoinsRequest) (*types.AccountCoinsResponse, *types.Error) {
 	if req.AccountIdentifier == nil {
 		return nil, service.WrapError(service.ErrInvalidInput, "account identifier is not provided")

--- a/service/backend/pchain/account_test.go
+++ b/service/backend/pchain/account_test.go
@@ -51,6 +51,14 @@ func TestAccountBalance(t *testing.T) {
 		utxo1Id, _ := ids.FromString(utxos[1].id)
 		stakeUtxoBytes := makeStakeUtxoBytes(t, backend, utxos[1].amount)
 
+		// Mock on GetAssetDescription
+		mockAssetDescription := &avm.GetAssetDescriptionReply{
+			Name:         "Avalanche",
+			Symbol:       mapper.AtomicAvaxCurrency.Symbol,
+			Denomination: 9,
+		}
+		pChainMock.Mock.On("GetAssetDescription", ctx, mapper.AtomicAvaxCurrency.Symbol).Return(mockAssetDescription, nil)
+
 		// once before other calls, once after
 		pChainMock.Mock.On("GetHeight", ctx).Return(blockHeight, nil).Twice()
 		// Make sure pagination works as well

--- a/service/backend/pchain/backend.go
+++ b/service/backend/pchain/backend.go
@@ -36,6 +36,7 @@ type Backend struct {
 	avaxAssetID            ids.ID
 }
 
+// NewBackend creates a P-chain service backend
 func NewBackend(
 	pClient client.PChainClient,
 	indexerParser indexer.Parser,
@@ -54,6 +55,7 @@ func NewBackend(
 	}
 }
 
+// ShouldHandleRequest returns whether a given request should be handled by this backend
 func (b *Backend) ShouldHandleRequest(req interface{}) bool {
 	switch r := req.(type) {
 	case *types.AccountBalanceRequest:

--- a/service/backend/pchain/block.go
+++ b/service/backend/pchain/block.go
@@ -274,7 +274,7 @@ func (b *Backend) newTxParser(
 		return nil, err
 	}
 
-	return pmapper.NewTxParser(false, hrp, chainIDs, inputAddresses, dependencyTxs)
+	return pmapper.NewTxParser(false, hrp, chainIDs, inputAddresses, dependencyTxs, b.pClient, b.avaxAssetID)
 }
 
 func (b *Backend) getChainIDs(ctx context.Context) (map[string]string, error) {

--- a/service/backend/pchain/construction.go
+++ b/service/backend/pchain/construction.go
@@ -24,10 +24,12 @@ var (
 	errNoTxGiven     = errors.New("no transaction was given")
 )
 
+// ConstructionDerive implements /construction/derive endpoint for P-chain
 func (b *Backend) ConstructionDerive(ctx context.Context, req *types.ConstructionDeriveRequest) (*types.ConstructionDeriveResponse, *types.Error) {
 	return common.DeriveBech32Address(b.fac, mapper.PChainNetworkIdentifier, req)
 }
 
+// ConstructionPreprocess implements /construction/preprocess endpoint for P-chain
 func (b *Backend) ConstructionPreprocess(
 	ctx context.Context,
 	req *types.ConstructionPreprocessRequest,
@@ -48,6 +50,7 @@ func (b *Backend) ConstructionPreprocess(
 	}, nil
 }
 
+// ConstructionMetadata implements /construction/metadata endpoint for P-chain
 func (b *Backend) ConstructionMetadata(
 	ctx context.Context,
 	req *types.ConstructionMetadataRequest,
@@ -183,6 +186,7 @@ func (b *Backend) getBaseTxFee(ctx context.Context) (*types.Amount, error) {
 	return suggestedFee, nil
 }
 
+// ConstructionPayloads implements /construction/payloads endpoint for P-chain
 func (b *Backend) ConstructionPayloads(ctx context.Context, req *types.ConstructionPayloadsRequest) (*types.ConstructionPayloadsResponse, *types.Error) {
 	builder := pTxBuilder{
 		avaxAssetID:  b.avaxAssetID,
@@ -192,6 +196,7 @@ func (b *Backend) ConstructionPayloads(ctx context.Context, req *types.Construct
 	return common.BuildPayloads(builder, req)
 }
 
+// ConstructionParse implements /construction/parse endpoint for P-chain
 func (b *Backend) ConstructionParse(ctx context.Context, req *types.ConstructionParseRequest) (*types.ConstructionParseResponse, *types.Error) {
 	rosettaTx, err := b.parsePayloadTxFromString(req.Transaction)
 	if err != nil {
@@ -216,6 +221,7 @@ func (b *Backend) ConstructionParse(ctx context.Context, req *types.Construction
 	return common.Parse(txParser, rosettaTx, req.Signed)
 }
 
+// ConstructionCombine implements /construction/combine endpoint for P-chain
 func (b *Backend) ConstructionCombine(ctx context.Context, req *types.ConstructionCombineRequest) (*types.ConstructionCombineResponse, *types.Error) {
 	rosettaTx, err := b.parsePayloadTxFromString(req.UnsignedTransaction)
 	if err != nil {
@@ -225,6 +231,7 @@ func (b *Backend) ConstructionCombine(ctx context.Context, req *types.Constructi
 	return common.Combine(b, rosettaTx, req.Signatures)
 }
 
+// CombineTx implements P-chain specific logic for combining unsigned transactions and signatures
 func (b *Backend) CombineTx(tx common.AvaxTx, signatures []*types.Signature) (common.AvaxTx, *types.Error) {
 	pTx, ok := tx.(*pTx)
 	if !ok {
@@ -282,6 +289,7 @@ func getTxInputs(
 	}
 }
 
+// ConstructionHash implements /construction/hash endpoint for P-chain
 func (b *Backend) ConstructionHash(
 	ctx context.Context,
 	req *types.ConstructionHashRequest,
@@ -294,6 +302,7 @@ func (b *Backend) ConstructionHash(
 	return common.HashTx(rosettaTx)
 }
 
+// ConstructionSubmit implements /construction/submit endpoint for P-chain
 func (b *Backend) ConstructionSubmit(
 	ctx context.Context,
 	req *types.ConstructionSubmitRequest,
@@ -306,7 +315,7 @@ func (b *Backend) ConstructionSubmit(
 	return common.SubmitTx(ctx, b, rosettaTx)
 }
 
-// Defining IssueTx here without rpc.Options... to be able to use it with common.SubmitTx
+// IssueTx broadcasts given transaction on P-chain
 func (b *Backend) IssueTx(ctx context.Context, txByte []byte) (ids.ID, error) {
 	return b.pClient.IssueTx(ctx, txByte)
 }

--- a/service/backend/pchain/construction.go
+++ b/service/backend/pchain/construction.go
@@ -214,8 +214,9 @@ func (b *Backend) ConstructionParse(ctx context.Context, req *types.Construction
 	}
 
 	txParser := pTxParser{
-		hrp:      hrp,
-		chainIDs: chainIDs,
+		hrp:         hrp,
+		chainIDs:    chainIDs,
+		avaxAssetID: b.avaxAssetID,
 	}
 
 	return common.Parse(txParser, rosettaTx, req.Signed)

--- a/service/backend/pchain/indexer/parser.go
+++ b/service/backend/pchain/indexer/parser.go
@@ -27,11 +27,17 @@ var errParserUninitialized = errors.New("uninitialized parser")
 
 const genesisTimestamp = 1599696000
 
+// Parser defines the interface for a P-chain indexer parser
 type Parser interface {
+	// GetGenesisBlock parses and returns the Genesis block
 	GetGenesisBlock(ctx context.Context) (*ParsedGenesisBlock, error)
+	// GetPlatformHeight returns the current block height of P-chain
 	GetPlatformHeight(ctx context.Context) (uint64, error)
+	// ParseCurrentBlock parses and returns the current tip of P-chain
 	ParseCurrentBlock(ctx context.Context) (*ParsedBlock, error)
+	// ParseBlockAtIndex parses and returns the block at the specified index
 	ParseBlockAtIndex(ctx context.Context, index uint64) (*ParsedBlock, error)
+	// ParseBlockAtIndex parses and returns the block with the specified hash
 	ParseBlockWithHash(ctx context.Context, hash string) (*ParsedBlock, error)
 }
 
@@ -53,6 +59,7 @@ type parser struct {
 	genesisTimestamp time.Time
 }
 
+// NewParser creates a new P-chain indexer parser
 func NewParser(pChainClient client.PChainClient) (Parser, error) {
 	errs := wrappers.Errs{}
 
@@ -168,7 +175,7 @@ func (p *parser) ParseBlockAtIndex(ctx context.Context, index uint64) (*ParsedBl
 		return nil, err
 	}
 
-	// in P-chain container indices start from 0 while corresponding block indices start from 1
+	// P-chain indexer container indices start from 0 while corresponding block indices start from 1
 	// therefore containers are looked up with index - 1
 	// genesis does not cause a problem here as it is handled in a separate code path
 	container, err := p.pChainClient.GetContainerByIndex(ctx, index-1)

--- a/service/backend/pchain/indexer/parser.go
+++ b/service/backend/pchain/indexer/parser.go
@@ -23,9 +23,11 @@ import (
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 )
 
-var errParserUninitialized = errors.New("uninitialized parser")
+var (
+	errParserUninitialized = errors.New("uninitialized parser")
 
-const genesisTimestamp = 1599696000
+	genesisTimestamp = time.Date(2020, time.September, 10, 0, 0, 0, 0, time.UTC).Unix()
+)
 
 // Parser defines the interface for a P-chain indexer parser
 type Parser interface {

--- a/service/backend/pchain/indexer/types.go
+++ b/service/backend/pchain/indexer/types.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 )
 
+// ParsedBlock contains block details parsed from indexer containers
 type ParsedBlock struct {
 	BlockID   ids.ID    `json:"id"`
 	BlockType string    `json:"type"`
@@ -16,17 +17,20 @@ type ParsedBlock struct {
 	Proposer  `json:"proposer"`
 }
 
+// GenesisBlockData contains Genesis state details
 type GenesisBlockData struct {
 	Message       string          `json:"message"`
 	InitialSupply uint64          `json:"initialSupply"`
 	UTXOs         []*genesis.UTXO `json:"utxos"`
 }
 
+// ParsedGenesisBlock contains Genesis state details
 type ParsedGenesisBlock struct {
 	ParsedBlock
 	GenesisBlockData `json:"data"`
 }
 
+// Proposer contains the details of block proposers
 type Proposer struct {
 	ID           ids.ID     `json:"id"`
 	ParentID     ids.ID     `json:"parent"`

--- a/service/backend/pchain/network.go
+++ b/service/backend/pchain/network.go
@@ -10,10 +10,13 @@ import (
 	"github.com/ava-labs/avalanche-rosetta/service"
 )
 
+// NetworkIdentifier returns P-chain network identifier
+// used by /network/list endpoint to list available networks
 func (b *Backend) NetworkIdentifier() *types.NetworkIdentifier {
 	return b.networkIdentifier
 }
 
+// NetworkStatus implements /network/status endpoint for P-chain
 func (b *Backend) NetworkStatus(ctx context.Context, req *types.NetworkRequest) (*types.NetworkStatusResponse, *types.Error) {
 	// Fetch peers
 	infoPeers, err := b.pClient.Peers(ctx)
@@ -61,6 +64,7 @@ func (b *Backend) NetworkStatus(ctx context.Context, req *types.NetworkRequest) 
 	}, nil
 }
 
+// NetworkOptions implements /network/options endpoint for P-chain
 func (b *Backend) NetworkOptions(ctx context.Context, request *types.NetworkRequest) (*types.NetworkOptionsResponse, *types.Error) {
 	return &types.NetworkOptionsResponse{
 		Version: &types.Version{

--- a/service/backend/pchain/types.go
+++ b/service/backend/pchain/types.go
@@ -55,14 +55,19 @@ func (p *pTx) SigningPayload() ([]byte, error) {
 	return hash, nil
 }
 
-func (p *pTx) Hash() ([]byte, error) {
-	bytes, err := p.Codec.Marshal(p.CodecVersion, &p.Tx)
+func (p *pTx) Hash() (ids.ID, error) {
+	unsignedBytes, err := p.Codec.Marshal(p.CodecVersion, &p.Tx.Unsigned)
 	if err != nil {
-		return nil, err
+		return ids.Empty, err
 	}
 
-	hash := hashing.ComputeHash256(bytes)
-	return hash, nil
+	signedBytes, err := p.Codec.Marshal(p.CodecVersion, &p.Tx)
+	if err != nil {
+		return ids.Empty, err
+	}
+
+	p.Tx.Initialize(unsignedBytes, signedBytes)
+	return p.Tx.ID(), nil
 }
 
 type pTxBuilder struct {

--- a/service/backend/pchain/types.go
+++ b/service/backend/pchain/types.go
@@ -17,6 +17,7 @@ import (
 
 var errInvalidTransaction = errors.New("invalid transaction")
 
+// AccountBalance contains P-chain account balances
 type AccountBalance struct {
 	Total              uint64
 	Unlocked           uint64

--- a/service/backend/pchain/types.go
+++ b/service/backend/pchain/types.go
@@ -103,8 +103,9 @@ func (p pTxBuilder) BuildTx(operations []*types.Operation, metadataMap map[strin
 }
 
 type pTxParser struct {
-	hrp      string
-	chainIDs map[string]string
+	hrp         string
+	chainIDs    map[string]string
+	avaxAssetID ids.ID
 }
 
 func (p pTxParser) ParseTx(tx *common.RosettaTx, inputAddresses map[string]*types.AccountIdentifier) ([]*types.Operation, error) {
@@ -113,7 +114,7 @@ func (p pTxParser) ParseTx(tx *common.RosettaTx, inputAddresses map[string]*type
 		return nil, errInvalidTransaction
 	}
 
-	parser, err := pmapper.NewTxParser(true, p.hrp, p.chainIDs, inputAddresses, nil)
+	parser, err := pmapper.NewTxParser(true, p.hrp, p.chainIDs, inputAddresses, nil, nil, p.avaxAssetID)
 	if err != nil {
 		return nil, err
 	}

--- a/service/service_account.go
+++ b/service/service_account.go
@@ -18,9 +18,18 @@ import (
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 )
 
+// AccountBackend represents a backend that implements /account family of apis for a subset of requests.
+// Endpoint handlers in this file delegates requests to corresponding backends based on the request.
+// Each backend implements a ShouldHandleRequest method to determine whether that backend should handle the given request.
+//
+// P-chain and C-chain atomic transaction logic are implemented in pchain.Backend and cchainatomictx.Backend respectively.
+// Eventually, the C-chain non-atomic transaction logic implemented in this file should be extracted to its own backend as well.
 type AccountBackend interface {
+	// ShouldHandleRequest returns whether a given request should be handled by this backend
 	ShouldHandleRequest(req interface{}) bool
+	// AccountBalance implements /account/balance endpoint for this backend
 	AccountBalance(ctx context.Context, req *types.AccountBalanceRequest) (*types.AccountBalanceResponse, *types.Error)
+	// AccountCoins implements /account/coins endpoint for this backend
 	AccountCoins(ctx context.Context, req *types.AccountCoinsRequest) (*types.AccountCoinsResponse, *types.Error)
 }
 

--- a/service/service_block.go
+++ b/service/service_block.go
@@ -17,9 +17,18 @@ import (
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 )
 
+// BlockBackend represents a backend that implements /block family of apis for a subset of requests
+// Endpoint handlers in this file delegates requests to corresponding backends based on the request.
+// Each backend implements a ShouldHandleRequest method to determine whether that backend should handle the given request.
+//
+// P-chain support is implemented in pchain.Backend which implements this interface.
+// Eventually, the C-chain block logic implemented in this file should be extracted to its own backend as well.
 type BlockBackend interface {
+	// ShouldHandleRequest returns whether a given request should be handled by this backend
 	ShouldHandleRequest(req interface{}) bool
+	// Block implements /block endpoint for this backend
 	Block(ctx context.Context, request *types.BlockRequest) (*types.BlockResponse, *types.Error)
+	// BlockTransaction implements /block/transaction endpoint for this backend
 	BlockTransaction(ctx context.Context, request *types.BlockTransactionRequest) (*types.BlockTransactionResponse, *types.Error)
 }
 

--- a/service/service_construction.go
+++ b/service/service_construction.go
@@ -30,15 +30,30 @@ const (
 	transferDataLength  = 68                          // 4 (method id) + 2*32 (args)
 )
 
+// ConstructionBackend represents a backend that implements /construction family of apis for a subset of requests.
+// Endpoint handlers in this file delegates requests to corresponding backends based on the request.
+// Each backend implements a ShouldHandleRequest method to determine whether that backend should handle the given request.
+//
+// P-chain and C-chain atomic transaction logic are implemented in pchain.Backend and cchainatomictx.Backend respectively.
+// Eventually, the C-chain non-atomic transaction logic implemented in this file should be extracted to its own backend as well.
 type ConstructionBackend interface {
+	// ShouldHandleRequest returns whether a given request should be handled by this backend
 	ShouldHandleRequest(req interface{}) bool
+	// ConstructionDerive implements /construction/derive endpoint for this backend
 	ConstructionDerive(ctx context.Context, req *types.ConstructionDeriveRequest) (*types.ConstructionDeriveResponse, *types.Error)
+	// ConstructionPreprocess implements /construction/preprocess endpoint for this backend
 	ConstructionPreprocess(ctx context.Context, req *types.ConstructionPreprocessRequest) (*types.ConstructionPreprocessResponse, *types.Error)
+	// ConstructionMetadata implements /construction/metadata endpoint for this backend
 	ConstructionMetadata(ctx context.Context, req *types.ConstructionMetadataRequest) (*types.ConstructionMetadataResponse, *types.Error)
+	// ConstructionPayloads implements /construction/payloads endpoint for this backend
 	ConstructionPayloads(ctx context.Context, req *types.ConstructionPayloadsRequest) (*types.ConstructionPayloadsResponse, *types.Error)
+	// ConstructionParse implements /construction/parse endpoint for this backend
 	ConstructionParse(ctx context.Context, req *types.ConstructionParseRequest) (*types.ConstructionParseResponse, *types.Error)
+	// ConstructionCombine implements /construction/combine endpoint for this backend
 	ConstructionCombine(ctx context.Context, req *types.ConstructionCombineRequest) (*types.ConstructionCombineResponse, *types.Error)
+	// ConstructionHash implements /construction/hash endpoint for this backend
 	ConstructionHash(ctx context.Context, req *types.ConstructionHashRequest) (*types.TransactionIdentifierResponse, *types.Error)
+	// ConstructionSubmit implements /construction/submit endpoint for this backend
 	ConstructionSubmit(ctx context.Context, req *types.ConstructionSubmitRequest) (*types.TransactionIdentifierResponse, *types.Error)
 }
 

--- a/service/service_network.go
+++ b/service/service_network.go
@@ -12,10 +12,20 @@ import (
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 )
 
+// NetworkBackend represents a backend that implements /block family of apis for a subset of requests
+// Endpoint handlers in this file delegates requests to corresponding backends based on the request.
+// Each backend implements a ShouldHandleRequest method to determine whether that backend should handle the given request.
+//
+// P-chain support is implemented in pchain.Backend which implements this interface.
+// Eventually, the C-chain block logic implemented in this file should be extracted to its own backend as well.
 type NetworkBackend interface {
+	// ShouldHandleRequest returns whether a given request should be handled by this backend
 	ShouldHandleRequest(req interface{}) bool
+	// NetworkIdentifier returns the identifier of the network it supports
 	NetworkIdentifier() *types.NetworkIdentifier
+	// NetworkStatus implements /network/status endpoint for this backend
 	NetworkStatus(ctx context.Context, request *types.NetworkRequest) (*types.NetworkStatusResponse, *types.Error)
+	// NetworkOptions implements /network/options endpoint for this backend
 	NetworkOptions(ctx context.Context, request *types.NetworkRequest) (*types.NetworkOptionsResponse, *types.Error)
 }
 


### PR DESCRIPTION
- Added comments to exported types
- Made genesis timestamp definition in P-chain indexer parser more verbose
- Migrate Hash endpoint implementation to use avalanchego's id generation instead of copying it
- Added operation identifier to p-chain imported inputs/exported outputs metadata
- Fixed account balance and coins lookup to filter requested currencies and ensure currencies are properly extracted in block parsing