### PR TITLE
Fixed Pchain Indexer parser  + minor cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Start the server by running the following command:
 ```bash
 ./rosetta-server -config=./config.json
 ```
+
 ## Configuration
 
 Full configuration example:
@@ -154,7 +155,7 @@ Run the construction check for ERC-20s:
 make check-testnet-construction-erc20
 ```
 
-## Rebuild the ContractInfoToken.go autogen file.
+## Rebuild the ContractInfoToken.go autogen file
 
 ```bash
 abigen --abi contractInfo.abi --pkg main --type ContractInfoToken --out client/contractInfoToken.go

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Before you start running the server you need to create a configuration file:
 
 ```json
 {
-  "rpc_endpoint": "https://api.avax-test.network",
+  "rpc_base_url": "https://api.avax-test.network",
   "mode": "online",
   "listen_addr": "0.0.0.0:8080",
   "genesis_block_hash" :"0x31ced5b9beb7f8782b014660da0cb18cc409f121f408186886e1ca3e8eeca96b",
@@ -53,7 +53,7 @@ Full configuration example:
 ```json
 {
   "mode": "online",
-  "rpc_endpoint": "http://localhost:9650",
+  "rpc_base_url": "http://localhost:9650",
   "listen_addr": "0.0.0.0:8080",
   "network_name": "Fuji",
   "chain_id": 43113,
@@ -71,7 +71,7 @@ Where:
 | Name          | Type    | Default | Description
 |---------------|---------|---------|-------------------------------------------
 | mode          | string  | `online` | Mode of operations. One of: `online`, `offline`
-| rpc_endpoint  | string  | `http://localhost:9650` | Avalanche RPC endpoint
+| rpc_base_url  | string  | `http://localhost:9650` | Avalanche RPC base url
 | listen_addr   | string  | `http://localhost:8080` | Rosetta server listen address (host/port)
 | network_name  | string  | -       | Avalanche network name
 | chain_id      | integer | -       | Avalanche C-Chain ID

--- a/client/client.go
+++ b/client/client.go
@@ -64,7 +64,7 @@ func NewClient(ctx context.Context, endpoint string) (Client, error) {
 		return nil, err
 	}
 
-	return client{
+	return &client{
 		Client:         info.NewClient(endpoint),
 		EvmClient:      evm.NewClient(endpoint, "C"),
 		EthClient:      eth,

--- a/client/pchainclient.go
+++ b/client/pchainclient.go
@@ -78,14 +78,14 @@ type pchainClient struct {
 }
 
 // NewPChainClient returns a new client for Avalanche APIs related to P-chain
-func NewPChainClient(ctx context.Context, endpoint, indexerEndpoint string) PChainClient {
-	endpoint = strings.TrimSuffix(endpoint, "/")
+func NewPChainClient(ctx context.Context, rpcBaseURL, indexerBaseURL string) PChainClient {
+	rpcBaseURL = strings.TrimSuffix(rpcBaseURL, "/")
 
 	return pchainClient{
-		platformvmClient: platformvm.NewClient(endpoint),
-		xChainClient:     avm.NewClient(endpoint, "X"),
-		infoClient:       info.NewClient(endpoint),
-		indexerClient:    indexer.NewClient(indexerEndpoint + "/ext/index/P/block"),
+		platformvmClient: platformvm.NewClient(rpcBaseURL),
+		xChainClient:     avm.NewClient(rpcBaseURL, "X"),
+		infoClient:       info.NewClient(rpcBaseURL),
+		indexerClient:    indexer.NewClient(indexerBaseURL + "/ext/index/P/block"),
 	}
 }
 

--- a/client/pchainclient.go
+++ b/client/pchainclient.go
@@ -27,7 +27,6 @@ type PChainClient interface {
 	GetLastAccepted(context.Context, ...rpc.Option) (indexer.Container, error)
 
 	// platformvm.Client methods
-
 	GetUTXOs(
 		ctx context.Context,
 		addrs []ids.ShortID,
@@ -54,7 +53,6 @@ type PChainClient interface {
 	GetStake(ctx context.Context, addrs []ids.ShortID, options ...rpc.Option) (map[ids.ID]uint64, [][]byte, error)
 
 	// avm.Client methods
-
 	GetAssetDescription(ctx context.Context, assetID string, options ...rpc.Option) (*avm.GetAssetDescriptionReply, error)
 
 	// info.Client methods

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -22,8 +22,8 @@ var (
 
 type config struct {
 	Mode             string `json:"mode"`
-	RPCEndpoint      string `json:"rpc_endpoint"`
-	IndexerEndpoint  string `json:"indexer_endpoint"`
+	RPCBaseUrl       string `json:"rpc_base_url"`
+	IndexerBaseUrl   string `json:"indexer_base_url"`
 	ListenAddr       string `json:"listen_addr"`
 	NetworkName      string `json:"network_name"`
 	ChainID          int64  `json:"chain_id"`
@@ -58,12 +58,12 @@ func (c *config) applyDefaults() {
 		c.IngestionMode = service.StandardIngestion
 	}
 
-	if c.RPCEndpoint == "" {
-		c.RPCEndpoint = "http://localhost:9650"
+	if c.RPCBaseUrl == "" {
+		c.RPCBaseUrl = "http://localhost:9650"
 	}
 
-	if c.IndexerEndpoint == "" {
-		c.IndexerEndpoint = c.RPCEndpoint
+	if c.IndexerBaseUrl == "" {
+		c.IndexerBaseUrl = c.RPCBaseUrl
 	}
 
 	if c.ListenAddr == "" {

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -22,8 +22,8 @@ var (
 
 type config struct {
 	Mode             string `json:"mode"`
-	RPCBaseUrl       string `json:"rpc_base_url"`
-	IndexerBaseUrl   string `json:"indexer_base_url"`
+	RPCBaseURL       string `json:"rpc_base_url"`
+	IndexerBaseURL   string `json:"indexer_base_url"`
 	ListenAddr       string `json:"listen_addr"`
 	NetworkName      string `json:"network_name"`
 	ChainID          int64  `json:"chain_id"`
@@ -58,12 +58,12 @@ func (c *config) applyDefaults() {
 		c.IngestionMode = service.StandardIngestion
 	}
 
-	if c.RPCBaseUrl == "" {
-		c.RPCBaseUrl = "http://localhost:9650"
+	if c.RPCBaseURL == "" {
+		c.RPCBaseURL = "http://localhost:9650"
 	}
 
-	if c.IndexerBaseUrl == "" {
-		c.IndexerBaseUrl = c.RPCBaseUrl
+	if c.IndexerBaseURL == "" {
+		c.IndexerBaseURL = c.RPCBaseURL
 	}
 
 	if c.ListenAddr == "" {

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -72,8 +72,6 @@ func (c *config) applyDefaults() {
 }
 
 func (c *config) validate() error {
-	c.applyDefaults()
-
 	if !(c.Mode == service.ModeOffline || c.Mode == service.ModeOnline) {
 		return errInvalidMode
 	}

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -12,7 +12,6 @@ import (
 )
 
 var (
-	errMissingRPC              = errors.New("avalanche rpc endpoint is not provided")
 	errInvalidMode             = errors.New("invalid rosetta mode")
 	errGenesisBlockRequired    = errors.New("genesis block hash is not provided")
 	errInvalidTokenAddress     = errors.New("invalid token address provided")
@@ -50,7 +49,7 @@ func readConfig(path string) (*config, error) {
 	return cfg, err
 }
 
-func (c *config) ApplyDefaults() {
+func (c *config) applyDefaults() {
 	if c.Mode == "" {
 		c.Mode = service.ModeOnline
 	}
@@ -72,12 +71,8 @@ func (c *config) ApplyDefaults() {
 	}
 }
 
-func (c *config) Validate() error {
-	c.ApplyDefaults()
-
-	if c.RPCEndpoint == "" {
-		return errMissingRPC
-	}
+func (c *config) validate() error {
+	c.applyDefaults()
 
 	if !(c.Mode == service.ModeOffline || c.Mode == service.ModeOnline) {
 		return errInvalidMode
@@ -105,7 +100,7 @@ func (c *config) Validate() error {
 	return nil
 }
 
-func (c *config) ValidateWhitelistOnlyValidErc20s(cli client.Client) error {
+func (c *config) validateWhitelistOnlyValidErc20s(cli client.Client) error {
 	for _, token := range c.TokenWhiteList {
 		ethAddress := ethcommon.HexToAddress(token)
 		symbol, decimals, err := cli.GetContractInfo(ethAddress, true)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -53,6 +53,10 @@ func main() {
 	if err != nil {
 		log.Fatal("config read error:", err)
 	}
+
+	// set defaults for unspecified configs
+	cfg.applyDefaults()
+
 	if err := cfg.validate(); err != nil {
 		log.Fatal("config validation error:", err)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -53,7 +53,7 @@ func main() {
 	if err != nil {
 		log.Fatal("config read error:", err)
 	}
-	if err := cfg.Validate(); err != nil {
+	if err := cfg.validate(); err != nil {
 		log.Fatal("config validation error:", err)
 	}
 
@@ -68,7 +68,7 @@ func main() {
 	//
 	// TODO: Only perform this check after the underlying node is bootstrapped
 	if cfg.Mode == service.ModeOnline && cfg.ValidateERC20Whitelist {
-		if err := cfg.ValidateWhitelistOnlyValidErc20s(apiClient); err != nil {
+		if err := cfg.validateWhitelistOnlyValidErc20s(apiClient); err != nil {
 			log.Fatal("token whitelist validation error:", err)
 		}
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -57,7 +57,7 @@ func main() {
 		log.Fatal("config validation error:", err)
 	}
 
-	apiClient, err := client.NewClient(context.Background(), cfg.RPCEndpoint)
+	apiClient, err := client.NewClient(context.Background(), cfg.RPCBaseUrl)
 	if err != nil {
 		log.Fatal("client init error:", err)
 	}
@@ -163,7 +163,7 @@ func main() {
 		log.Fatal("parse asset id failed:", err)
 	}
 
-	pChainClient := client.NewPChainClient(context.Background(), cfg.RPCEndpoint, cfg.IndexerEndpoint)
+	pChainClient := client.NewPChainClient(context.Background(), cfg.RPCBaseUrl, cfg.IndexerBaseUrl)
 	pIndexerParser, err := indexer.NewParser(pChainClient)
 	if err != nil {
 		log.Fatal("unable to initialize p-chain indexer parser:", err)
@@ -185,7 +185,7 @@ func main() {
 		service.BlockchainName,
 		cfg.ChainID,
 		cfg.NetworkName,
-		cfg.RPCEndpoint,
+		cfg.RPCBaseUrl,
 	)
 	log.Printf("starting rosetta server at %s\n", cfg.ListenAddr)
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -57,7 +57,7 @@ func main() {
 		log.Fatal("config validation error:", err)
 	}
 
-	apiClient, err := client.NewClient(context.Background(), cfg.RPCBaseUrl)
+	apiClient, err := client.NewClient(context.Background(), cfg.RPCBaseURL)
 	if err != nil {
 		log.Fatal("client init error:", err)
 	}
@@ -163,7 +163,7 @@ func main() {
 		log.Fatal("parse asset id failed:", err)
 	}
 
-	pChainClient := client.NewPChainClient(context.Background(), cfg.RPCBaseUrl, cfg.IndexerBaseUrl)
+	pChainClient := client.NewPChainClient(context.Background(), cfg.RPCBaseURL, cfg.IndexerBaseURL)
 	pIndexerParser, err := indexer.NewParser(pChainClient)
 	if err != nil {
 		log.Fatal("unable to initialize p-chain indexer parser:", err)
@@ -185,7 +185,7 @@ func main() {
 		service.BlockchainName,
 		cfg.ChainID,
 		cfg.NetworkName,
-		cfg.RPCBaseUrl,
+		cfg.RPCBaseURL,
 	)
 	log.Printf("starting rosetta server at %s\n", cfg.ListenAddr)
 

--- a/mocks/service/backend/parser.go
+++ b/mocks/service/backend/parser.go
@@ -58,13 +58,13 @@ func (_m *Parser) GetPlatformHeight(ctx context.Context) (uint64, error) {
 	return r0, r1
 }
 
-// ParseBlockAtIndex provides a mock function with given fields: ctx, index
-func (_m *Parser) ParseBlockAtIndex(ctx context.Context, index uint64) (*indexer.ParsedBlock, error) {
-	ret := _m.Called(ctx, index)
+// ParseBlockAtHeight provides a mock function with given fields: ctx, height
+func (_m *Parser) ParseBlockAtHeight(ctx context.Context, height uint64) (*indexer.ParsedBlock, error) {
+	ret := _m.Called(ctx, height)
 
 	var r0 *indexer.ParsedBlock
 	if rf, ok := ret.Get(0).(func(context.Context, uint64) *indexer.ParsedBlock); ok {
-		r0 = rf(ctx, index)
+		r0 = rf(ctx, height)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*indexer.ParsedBlock)
@@ -73,7 +73,7 @@ func (_m *Parser) ParseBlockAtIndex(ctx context.Context, index uint64) (*indexer
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, uint64) error); ok {
-		r1 = rf(ctx, index)
+		r1 = rf(ctx, height)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/service/backend/pchain/indexer/parser.go
+++ b/mocks/service/backend/pchain/indexer/parser.go
@@ -58,13 +58,13 @@ func (_m *Parser) GetPlatformHeight(ctx context.Context) (uint64, error) {
 	return r0, r1
 }
 
-// ParseBlockAtIndex provides a mock function with given fields: ctx, index
-func (_m *Parser) ParseBlockAtIndex(ctx context.Context, index uint64) (*indexer.ParsedBlock, error) {
-	ret := _m.Called(ctx, index)
+// ParseBlockAtHeight provides a mock function with given fields: ctx, height
+func (_m *Parser) ParseBlockAtHeight(ctx context.Context, height uint64) (*indexer.ParsedBlock, error) {
+	ret := _m.Called(ctx, height)
 
 	var r0 *indexer.ParsedBlock
 	if rf, ok := ret.Get(0).(func(context.Context, uint64) *indexer.ParsedBlock); ok {
-		r0 = rf(ctx, index)
+		r0 = rf(ctx, height)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*indexer.ParsedBlock)
@@ -73,7 +73,7 @@ func (_m *Parser) ParseBlockAtIndex(ctx context.Context, index uint64) (*indexer
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, uint64) error); ok {
-		r1 = rf(ctx, index)
+		r1 = rf(ctx, height)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/service/backend/pchain/account_test.go
+++ b/service/backend/pchain/account_test.go
@@ -40,7 +40,7 @@ func TestAccountBalance(t *testing.T) {
 	ctx := context.Background()
 	pChainMock := &mocks.PChainClient{}
 	parserMock := &idxmocks.Parser{}
-	parserMock.Mock.On("ParseBlockAtIndex", ctx, blockHeight).Return(parsedBlock, nil)
+	parserMock.Mock.On("ParseBlockAtHeight", ctx, blockHeight).Return(parsedBlock, nil)
 	backend := NewBackend(pChainMock, parserMock, avaxAssetID, nil)
 	backend.getUTXOsPageSize = 2
 
@@ -197,7 +197,7 @@ func TestAccountCoins(t *testing.T) {
 	ctx := context.Background()
 	pChainMock := &mocks.PChainClient{}
 	parserMock := &idxmocks.Parser{}
-	parserMock.Mock.On("ParseBlockAtIndex", ctx, blockHeight).Return(parsedBlock, nil)
+	parserMock.Mock.On("ParseBlockAtHeight", ctx, blockHeight).Return(parsedBlock, nil)
 	backend := NewBackend(pChainMock, parserMock, avaxAssetID, nil)
 
 	t.Run("Account Coins Test regular coins", func(t *testing.T) {

--- a/service/backend/pchain/backend.go
+++ b/service/backend/pchain/backend.go
@@ -90,7 +90,6 @@ func (b *Backend) ShouldHandleRequest(req interface{}) bool {
 }
 
 func (b *Backend) getGenesisBlock(ctx context.Context) (*indexer.ParsedGenesisBlock, error) {
-	// Initializing parser gives parsed genesis block
 	if b.genesisBlock != nil {
 		return b.genesisBlock, nil
 	}
@@ -99,14 +98,9 @@ func (b *Backend) getGenesisBlock(ctx context.Context) (*indexer.ParsedGenesisBl
 		return nil, err
 	}
 	b.genesisBlock = genesisBlock
-	b.genesisBlockIdentifier = b.buildGenesisBlockIdentifier(genesisBlock)
-
-	return genesisBlock, nil
-}
-
-func (b *Backend) buildGenesisBlockIdentifier(genesisBlock *indexer.ParsedGenesisBlock) *types.BlockIdentifier {
-	return &types.BlockIdentifier{
+	b.genesisBlockIdentifier = &types.BlockIdentifier{
 		Index: int64(genesisBlock.Height),
 		Hash:  genesisBlock.BlockID.String(),
 	}
+	return genesisBlock, nil
 }

--- a/service/backend/pchain/block.go
+++ b/service/backend/pchain/block.go
@@ -319,7 +319,7 @@ func (b *Backend) getBlockDetails(ctx context.Context, index int64, hash string)
 		blockHeight = height
 	}
 
-	return b.indexerParser.ParseBlockAtIndex(ctx, blockHeight)
+	return b.indexerParser.ParseBlockAtHeight(ctx, blockHeight)
 }
 
 func (b *Backend) getBlockHeight(ctx context.Context, hash string) (uint64, error) {

--- a/service/backend/pchain/indexer/parser.go
+++ b/service/backend/pchain/indexer/parser.go
@@ -72,7 +72,15 @@ func NewParser(pChainClient client.PChainClient) (Parser, error) {
 }
 
 func (p *parser) GetPlatformHeight(ctx context.Context) (uint64, error) {
-	return p.pChainClient.GetHeight(ctx)
+	container, err := p.pChainClient.GetLastAccepted(ctx)
+	if err != nil {
+		return 0, err
+	}
+	blk, err := p.parseContainer(container)
+	if err != nil {
+		return 0, err
+	}
+	return blk.Height, nil
 }
 
 func (p *parser) GetGenesisBlock(ctx context.Context) (*ParsedGenesisBlock, error) {

--- a/service/backend/pchain/indexer/parser.go
+++ b/service/backend/pchain/indexer/parser.go
@@ -2,7 +2,6 @@ package indexer
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -23,11 +22,7 @@ import (
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 )
 
-var (
-	errParserUninitialized = errors.New("uninitialized parser")
-
-	genesisTimestamp = time.Date(2020, time.September, 10, 0, 0, 0, 0, time.UTC).Unix()
-)
+var genesisTimestamp = time.Date(2020, time.September, 10, 0, 0, 0, 0, time.UTC).Unix()
 
 // Parser defines the interface for a P-chain indexer parser
 type Parser interface {
@@ -95,8 +90,7 @@ func (p *parser) initCtx(ctx context.Context) error {
 }
 
 func (p *parser) GetPlatformHeight(ctx context.Context) (uint64, error) {
-	err := p.initCtx(ctx)
-	if err != nil {
+	if err := p.initCtx(ctx); err != nil {
 		return 0, err
 	}
 
@@ -104,8 +98,7 @@ func (p *parser) GetPlatformHeight(ctx context.Context) (uint64, error) {
 }
 
 func (p *parser) GetGenesisBlock(ctx context.Context) (*ParsedGenesisBlock, error) {
-	err := p.initCtx(ctx)
-	if err != nil {
+	if err := p.initCtx(ctx); err != nil {
 		return nil, err
 	}
 
@@ -158,8 +151,7 @@ func (p *parser) GetGenesisBlock(ctx context.Context) (*ParsedGenesisBlock, erro
 }
 
 func (p *parser) ParseCurrentBlock(ctx context.Context) (*ParsedBlock, error) {
-	err := p.initCtx(ctx)
-	if err != nil {
+	if err := p.initCtx(ctx); err != nil {
 		return nil, err
 	}
 
@@ -172,8 +164,7 @@ func (p *parser) ParseCurrentBlock(ctx context.Context) (*ParsedBlock, error) {
 }
 
 func (p *parser) ParseBlockAtIndex(ctx context.Context, index uint64) (*ParsedBlock, error) {
-	err := p.initCtx(ctx)
-	if err != nil {
+	if err := p.initCtx(ctx); err != nil {
 		return nil, err
 	}
 
@@ -189,8 +180,7 @@ func (p *parser) ParseBlockAtIndex(ctx context.Context, index uint64) (*ParsedBl
 }
 
 func (p *parser) ParseBlockWithHash(ctx context.Context, hash string) (*ParsedBlock, error) {
-	err := p.initCtx(ctx)
-	if err != nil {
+	if err := p.initCtx(ctx); err != nil {
 		return nil, err
 	}
 
@@ -213,10 +203,6 @@ func (p *parser) parseBlockBytes(proposerBytes []byte) (*ParsedBlock, error) {
 	proposer, bytes, err := getProposerFromBytes(proposerBytes)
 	if err != nil {
 		return nil, fmt.Errorf("fetching proposer from block bytes errored with %w", err)
-	}
-
-	if p.genesisTimestamp.IsZero() {
-		return nil, errParserUninitialized
 	}
 
 	blk, err := pBlocks.Parse(p.codec, bytes)

--- a/service/backend/pchain/indexer/parser.go
+++ b/service/backend/pchain/indexer/parser.go
@@ -200,13 +200,17 @@ func (p *parser) parseContainer(container indexer.Container) (*ParsedBlock, erro
 		return nil, fmt.Errorf("unmarshaling block bytes errored with %w", err)
 	}
 
+	txes := blk.Txs()
+	if txes == nil {
+		txes = []*txs.Tx{}
+	}
 	return &ParsedBlock{
 		BlockID:   blk.ID(),
 		BlockType: fmt.Sprintf("%T", blk),
 		ParentID:  blk.Parent(),
 		Timestamp: container.Timestamp,
 		Height:    blk.Height(),
-		Txs:       blk.Txs(),
+		Txs:       txes,
 		Proposer:  proBlkData,
 	}, nil
 }

--- a/service/backend/pchain/indexer/parser.go
+++ b/service/backend/pchain/indexer/parser.go
@@ -40,6 +40,11 @@ type Parser interface {
 var _ Parser = &parser{}
 
 type parser struct {
+	// ideally parser should rely only on pchain indexer apis.
+	// The full PChainClient is currently needed just to retrieve
+	// NetworkID.
+	// TODO: reduce pChainClient to indexer methods only
+	// TODO: consider introducing a cache for parsed blocks
 	pChainClient client.PChainClient
 
 	codec        codec.Manager

--- a/service/backend/pchain/indexer/parser.go
+++ b/service/backend/pchain/indexer/parser.go
@@ -42,9 +42,8 @@ type Parser interface {
 var _ Parser = &parser{}
 
 type parser struct {
-	networkID   uint32
-	avaxAssetID ids.ID
-	aliaser     ids.Aliaser
+	networkID uint32
+	aliaser   ids.Aliaser
 
 	codec        codec.Manager
 	codecVersion uint16
@@ -105,9 +104,8 @@ func (p *parser) GetGenesisBlock(ctx context.Context) (*ParsedGenesisBlock, erro
 
 	errs := wrappers.Errs{}
 
-	bytes, avaxAssetID, err := genesis.FromConfig(genesis.GetConfig(p.networkID))
+	bytes, _, err := genesis.FromConfig(genesis.GetConfig(p.networkID))
 	errs.Add(err)
-	p.avaxAssetID = avaxAssetID
 
 	genesisState, err := pGenesis.Parse(bytes)
 	errs.Add(err)

--- a/service/backend/pchain/indexer/parser.go
+++ b/service/backend/pchain/indexer/parser.go
@@ -52,8 +52,6 @@ type parser struct {
 	ctx *snow.Context
 
 	pChainClient client.PChainClient
-
-	genesisTimestamp time.Time
 }
 
 // NewParser creates a new P-chain indexer parser
@@ -64,11 +62,10 @@ func NewParser(pChainClient client.PChainClient) (Parser, error) {
 	errs.Add(aliaser.Alias(constants.PlatformChainID, mapper.PChainNetworkIdentifier))
 
 	return &parser{
-		codec:            pBlocks.Codec,
-		codecVersion:     pBlocks.Version,
-		pChainClient:     pChainClient,
-		aliaser:          aliaser,
-		genesisTimestamp: time.Unix(genesisTimestamp, 0),
+		codec:        pBlocks.Codec,
+		codecVersion: pBlocks.Version,
+		pChainClient: pChainClient,
+		aliaser:      aliaser,
 	}, errs.Err
 }
 
@@ -111,7 +108,7 @@ func (p *parser) GetGenesisBlock(ctx context.Context) (*ParsedGenesisBlock, erro
 	genesisState, err := pGenesis.Parse(bytes)
 	errs.Add(err)
 
-	p.genesisTimestamp = time.Unix(int64(genesisState.Timestamp), 0)
+	genesisTimestamp := time.Unix(int64(genesisState.Timestamp), 0)
 
 	var genesisTxs []*txs.Tx
 	genesisTxs = append(genesisTxs, genesisState.Validators...)
@@ -138,7 +135,7 @@ func (p *parser) GetGenesisBlock(ctx context.Context) (*ParsedGenesisBlock, erro
 			Height:    0,
 			BlockID:   genesisBlockID,
 			BlockType: "GenesisBlock",
-			Timestamp: p.genesisTimestamp.UnixMilli(),
+			Timestamp: genesisTimestamp.UnixMilli(),
 			Txs:       genesisTxs,
 			Proposer:  Proposer{},
 		},

--- a/service/backend/pchain/indexer/parser.go
+++ b/service/backend/pchain/indexer/parser.go
@@ -221,9 +221,14 @@ func (p *parser) parseContainer(container indexer.Container) (*ParsedBlock, erro
 		BlockID:   blk.ID(),
 		BlockType: fmt.Sprintf("%T", blk),
 		ParentID:  blk.Parent(),
-		Timestamp: container.Timestamp,
-		Height:    blk.Height(),
-		Txs:       txes,
-		Proposer:  proBlkData,
+
+		// TODO: we are considering different ways to build timestamp
+		// e.g. using Banff blocks timestamps/proposerVM timestamp.
+		// Update once agreement is reached
+		Timestamp: time.Unix(container.Timestamp, 0).UnixMilli(),
+
+		Height:   blk.Height(),
+		Txs:      txes,
+		Proposer: proBlkData,
 	}, nil
 }

--- a/service/backend/pchain/indexer/parser_test.go
+++ b/service/backend/pchain/indexer/parser_test.go
@@ -156,7 +156,7 @@ func TestFixtures(t *testing.T) {
 		// +1 because we do -1 inside parseBlockAtIndex
 		// and ins/outs are based on container ids
 		// instead of block ids
-		block, err := p.ParseBlockAtIndex(ctx, idx+1)
+		block, err := p.ParseBlockAtHeight(ctx, idx+1)
 		if err != nil {
 			panic(err)
 		}

--- a/service/backend/pchain/indexer/parser_test.go
+++ b/service/backend/pchain/indexer/parser_test.go
@@ -30,7 +30,27 @@ var (
 )
 
 // idxs of the containers we test against
-var idxs = []uint64{0, 1, 2, 8, 48, 173, 382, 911, 1603, 5981, 131475, 211277, 211333, 806002, 810424, 1000000, 1000001, 1000002, 1000004} //nolint:lll
+var idxs = []uint64{
+	0,
+	1,
+	2,
+	8,
+	48,
+	173,
+	382,
+	911,
+	1603,
+	5981,
+	131475,
+	211277,
+	211333,
+	806002,
+	810424,
+	1000000,
+	1000001,
+	1000002,
+	1000004,
+}
 
 // mainnet block 1 container bytes
 // parent id is 2FUFPVPxbTpKNn39moGSzsmGroYES4NZRdw3mJgNvMkMiMHJ9e which is the mainnet genesis block id
@@ -59,7 +79,6 @@ func TestMain(m *testing.M) {
 		ret := readFixture("ins/%v.json", idx)
 
 		var container indexer.Container
-
 		err := stdjson.Unmarshal(ret, &container)
 		if err != nil {
 			panic(err)
@@ -68,20 +87,15 @@ func TestMain(m *testing.M) {
 		pchainClient.On("GetContainerByIndex", ctx, idx).Return(container, nil).Once()
 	}
 
-	var err error
-
 	txID, err := ids.FromString("jWgE5KiiCejNYbYGDzhu9WAXrAdgwav9EXuycNVdB62rSU4tH")
 	if err != nil {
 		panic(err)
 	}
-
 	arg := &api.GetTxArgs{
 		TxID:     txID,
 		Encoding: formatting.Hex,
 	}
-
 	bytes := [][]byte{{0, 0, 96, 135, 38, 30, 158, 122, 109, 66, 126, 42, 192, 155, 20, 141, 194, 137, 85, 161, 188, 115, 215, 227, 44, 148, 7, 201, 191, 227, 25, 222, 126, 28, 0, 0, 0, 7, 33, 230, 115, 23, 203, 196, 190, 42, 235, 0, 103, 122, 214, 70, 39, 120, 168, 245, 34, 116, 185, 214, 5, 223, 37, 145, 178, 48, 39, 168, 125, 255, 0, 0, 0, 7, 0, 0, 0, 4, 238, 10, 47, 173, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 237, 104, 212, 116, 123, 119, 22, 41, 162, 163, 85, 62, 170, 126, 105, 250, 197, 149, 192, 120}} //nolint:lll
-
 	pchainClient.On("GetRewardUTXOs", ctx, arg).Return(bytes, nil).Once()
 
 	pchainClient.On("GetHeight", ctx, mock.Anything).Return(uint64(1000000), nil)

--- a/service/backend/pchain/indexer/testdata/outs/0.json
+++ b/service/backend/pchain/indexer/testdata/outs/0.json
@@ -2,7 +2,7 @@
   "id": "4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "2FUFPVPxbTpKNn39moGSzsmGroYES4NZRdw3mJgNvMkMiMHJ9e",
-  "timestamp": 1600740000000,
+  "timestamp": 1635980695,
   "height": 1,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/0.json
+++ b/service/backend/pchain/indexer/testdata/outs/0.json
@@ -2,7 +2,7 @@
   "id": "4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "2FUFPVPxbTpKNn39moGSzsmGroYES4NZRdw3mJgNvMkMiMHJ9e",
-  "timestamp": 1635980695,
+  "timestamp": 1635980695000,
   "height": 1,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/0.json
+++ b/service/backend/pchain/indexer/testdata/outs/0.json
@@ -2,7 +2,7 @@
   "id": "4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "2FUFPVPxbTpKNn39moGSzsmGroYES4NZRdw3mJgNvMkMiMHJ9e",
-  "timestamp": 1635980695000,
+  "timestamp": 1600740000000,
   "height": 1,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/1.json
+++ b/service/backend/pchain/indexer/testdata/outs/1.json
@@ -2,7 +2,7 @@
   "id": "2peK2rrira1UUdFuLWZTMHFdGe3JY8sQeKLfPj5jhPdK8mMAcJ",
   "type": "*blocks.ApricotCommitBlock",
   "parent": "4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi",
-  "timestamp": 1635980695000,
+  "timestamp": 1599696000000,
   "height": 2,
   "transactions": [],
   "proposer": {

--- a/service/backend/pchain/indexer/testdata/outs/1.json
+++ b/service/backend/pchain/indexer/testdata/outs/1.json
@@ -2,7 +2,7 @@
   "id": "2peK2rrira1UUdFuLWZTMHFdGe3JY8sQeKLfPj5jhPdK8mMAcJ",
   "type": "*blocks.ApricotCommitBlock",
   "parent": "4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi",
-  "timestamp": 1635980695,
+  "timestamp": 1635980695000,
   "height": 2,
   "transactions": [],
   "proposer": {

--- a/service/backend/pchain/indexer/testdata/outs/1.json
+++ b/service/backend/pchain/indexer/testdata/outs/1.json
@@ -2,7 +2,7 @@
   "id": "2peK2rrira1UUdFuLWZTMHFdGe3JY8sQeKLfPj5jhPdK8mMAcJ",
   "type": "*blocks.ApricotCommitBlock",
   "parent": "4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi",
-  "timestamp": 1599696000000,
+  "timestamp": 1635980695,
   "height": 2,
   "transactions": [],
   "proposer": {

--- a/service/backend/pchain/indexer/testdata/outs/1000000.json
+++ b/service/backend/pchain/indexer/testdata/outs/1000000.json
@@ -2,7 +2,7 @@
   "id": "d7WYmb8VeZNHsny3EJCwMm6QA37s1EHwMxw1Y71V3FqPZ5EFG",
   "type": "*blocks.ApricotStandardBlock",
   "parent": "5615di9ytxujackzaXNrVuWQy5y8Yrt8chPCscMr5Ku9YxJ1S",
-  "timestamp": 1638504075000,
+  "timestamp": 1638504076,
   "height": 1000001,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/1000000.json
+++ b/service/backend/pchain/indexer/testdata/outs/1000000.json
@@ -2,7 +2,7 @@
   "id": "d7WYmb8VeZNHsny3EJCwMm6QA37s1EHwMxw1Y71V3FqPZ5EFG",
   "type": "*blocks.ApricotStandardBlock",
   "parent": "5615di9ytxujackzaXNrVuWQy5y8Yrt8chPCscMr5Ku9YxJ1S",
-  "timestamp": 1638504076000,
+  "timestamp": 1638504075000,
   "height": 1000001,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/1000000.json
+++ b/service/backend/pchain/indexer/testdata/outs/1000000.json
@@ -2,7 +2,7 @@
   "id": "d7WYmb8VeZNHsny3EJCwMm6QA37s1EHwMxw1Y71V3FqPZ5EFG",
   "type": "*blocks.ApricotStandardBlock",
   "parent": "5615di9ytxujackzaXNrVuWQy5y8Yrt8chPCscMr5Ku9YxJ1S",
-  "timestamp": 1638504076,
+  "timestamp": 1638504076000,
   "height": 1000001,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/1000001.json
+++ b/service/backend/pchain/indexer/testdata/outs/1000001.json
@@ -2,7 +2,7 @@
   "id": "2Mbfba1sSJw9yrp1ZGpEs4aa7AFkBEofmrXty1CPL2hrnqGeVT",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "d7WYmb8VeZNHsny3EJCwMm6QA37s1EHwMxw1Y71V3FqPZ5EFG",
-  "timestamp": 1638504099,
+  "timestamp": 1638504099000,
   "height": 1000002,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/1000001.json
+++ b/service/backend/pchain/indexer/testdata/outs/1000001.json
@@ -2,7 +2,7 @@
   "id": "2Mbfba1sSJw9yrp1ZGpEs4aa7AFkBEofmrXty1CPL2hrnqGeVT",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "d7WYmb8VeZNHsny3EJCwMm6QA37s1EHwMxw1Y71V3FqPZ5EFG",
-  "timestamp": 1638504095000,
+  "timestamp": 1638504099,
   "height": 1000002,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/1000001.json
+++ b/service/backend/pchain/indexer/testdata/outs/1000001.json
@@ -2,7 +2,7 @@
   "id": "2Mbfba1sSJw9yrp1ZGpEs4aa7AFkBEofmrXty1CPL2hrnqGeVT",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "d7WYmb8VeZNHsny3EJCwMm6QA37s1EHwMxw1Y71V3FqPZ5EFG",
-  "timestamp": 1638504099000,
+  "timestamp": 1638504095000,
   "height": 1000002,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/1000002.json
+++ b/service/backend/pchain/indexer/testdata/outs/1000002.json
@@ -2,7 +2,7 @@
   "id": "bMRTouVMNG6m82UPnUg6QN2o9X19g6rkRtsJRSrSNiY7GaAjJ",
   "type": "*blocks.ApricotCommitBlock",
   "parent": "2Mbfba1sSJw9yrp1ZGpEs4aa7AFkBEofmrXty1CPL2hrnqGeVT",
-  "timestamp": 1638504099,
+  "timestamp": 1638504099000,
   "height": 1000003,
   "transactions": [],
   "proposer": {

--- a/service/backend/pchain/indexer/testdata/outs/1000002.json
+++ b/service/backend/pchain/indexer/testdata/outs/1000002.json
@@ -2,7 +2,7 @@
   "id": "bMRTouVMNG6m82UPnUg6QN2o9X19g6rkRtsJRSrSNiY7GaAjJ",
   "type": "*blocks.ApricotCommitBlock",
   "parent": "2Mbfba1sSJw9yrp1ZGpEs4aa7AFkBEofmrXty1CPL2hrnqGeVT",
-  "timestamp": 1638504099000,
+  "timestamp": 1599696000000,
   "height": 1000003,
   "transactions": [],
   "proposer": {

--- a/service/backend/pchain/indexer/testdata/outs/1000002.json
+++ b/service/backend/pchain/indexer/testdata/outs/1000002.json
@@ -2,12 +2,12 @@
   "id": "bMRTouVMNG6m82UPnUg6QN2o9X19g6rkRtsJRSrSNiY7GaAjJ",
   "type": "*blocks.ApricotCommitBlock",
   "parent": "2Mbfba1sSJw9yrp1ZGpEs4aa7AFkBEofmrXty1CPL2hrnqGeVT",
-  "timestamp": 1599696000000,
+  "timestamp": 1638504099,
   "height": 1000003,
   "transactions": [],
   "proposer": {
-    "id": "11111111111111111111111111111111LpoYY",
-    "parent": "11111111111111111111111111111111LpoYY",
+    "id": "oT3nzNB93Lz6vq7Z3BBzgrWYLtNZ6iq8c9V6CikKL5T9nBG4c",
+    "parent": "2jsPqeaxacqgMBjQFuiHGiwTjD4kbXqmgbVxXPjTCUtsY5CnJv",
     "nodeID": "NodeID-111111111111111111116DBWJs",
     "pChainHeight": 0,
     "timestamp": 0

--- a/service/backend/pchain/indexer/testdata/outs/1000004.json
+++ b/service/backend/pchain/indexer/testdata/outs/1000004.json
@@ -2,12 +2,12 @@
   "id": "2Kbis7MxM1MUqdfNxKdhP7FAhEdNYBHDvPivFWmGktDV9Au5nL",
   "type": "*blocks.ApricotCommitBlock",
   "parent": "DGRnAy4HYV52uWCRKZV6UXw9s9qZKCat5Xss8PANDaR5mngUz",
-  "timestamp": 1599696000000,
+  "timestamp": 1638504099,
   "height": 1000005,
   "transactions": [],
   "proposer": {
-    "id": "11111111111111111111111111111111LpoYY",
-    "parent": "11111111111111111111111111111111LpoYY",
+    "id": "2Rq1S9c78zZeVg51YB2oGZ6YGtLHkmKezTpAJgZeVS7QSL5pQZ",
+    "parent": "2fFCtHiHjdS2Vua7LuHorvMcTCtrDhs5oFAtHQiaRbcsDJi687",
     "nodeID": "NodeID-111111111111111111116DBWJs",
     "pChainHeight": 0,
     "timestamp": 0

--- a/service/backend/pchain/indexer/testdata/outs/1000004.json
+++ b/service/backend/pchain/indexer/testdata/outs/1000004.json
@@ -2,7 +2,7 @@
   "id": "2Kbis7MxM1MUqdfNxKdhP7FAhEdNYBHDvPivFWmGktDV9Au5nL",
   "type": "*blocks.ApricotCommitBlock",
   "parent": "DGRnAy4HYV52uWCRKZV6UXw9s9qZKCat5Xss8PANDaR5mngUz",
-  "timestamp": 1638504099,
+  "timestamp": 1638504099000,
   "height": 1000005,
   "transactions": [],
   "proposer": {

--- a/service/backend/pchain/indexer/testdata/outs/1000004.json
+++ b/service/backend/pchain/indexer/testdata/outs/1000004.json
@@ -2,7 +2,7 @@
   "id": "2Kbis7MxM1MUqdfNxKdhP7FAhEdNYBHDvPivFWmGktDV9Au5nL",
   "type": "*blocks.ApricotCommitBlock",
   "parent": "DGRnAy4HYV52uWCRKZV6UXw9s9qZKCat5Xss8PANDaR5mngUz",
-  "timestamp": 1638504099000,
+  "timestamp": 1599696000000,
   "height": 1000005,
   "transactions": [],
   "proposer": {

--- a/service/backend/pchain/indexer/testdata/outs/131475.json
+++ b/service/backend/pchain/indexer/testdata/outs/131475.json
@@ -2,7 +2,7 @@
   "id": "2DxASWodkHwmQURYjddSysMYiWoR2cArEaLEh6s6114gy2zSD4",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "guP5pc9yADiupb6riw8fPaWwNTpw5kPwhF43nM2csamDqrrNH",
-  "timestamp": 1635980780000,
+  "timestamp": 1599696000000,
   "height": 131476,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/131475.json
+++ b/service/backend/pchain/indexer/testdata/outs/131475.json
@@ -2,7 +2,7 @@
   "id": "2DxASWodkHwmQURYjddSysMYiWoR2cArEaLEh6s6114gy2zSD4",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "guP5pc9yADiupb6riw8fPaWwNTpw5kPwhF43nM2csamDqrrNH",
-  "timestamp": 1635980780,
+  "timestamp": 1635980780000,
   "height": 131476,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/131475.json
+++ b/service/backend/pchain/indexer/testdata/outs/131475.json
@@ -2,7 +2,7 @@
   "id": "2DxASWodkHwmQURYjddSysMYiWoR2cArEaLEh6s6114gy2zSD4",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "guP5pc9yADiupb6riw8fPaWwNTpw5kPwhF43nM2csamDqrrNH",
-  "timestamp": 1599696000000,
+  "timestamp": 1635980780,
   "height": 131476,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/1603.json
+++ b/service/backend/pchain/indexer/testdata/outs/1603.json
@@ -2,7 +2,7 @@
   "id": "2WSa91XbRZ7h1cHvH7Xp5A3o9etXF4bRCEpj8jdhShXF8Jodt7",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "2guuhVtf9anfhF1U5ngbVi4Kf9Wn68N5hguJ4dsDGsFouU9Adb",
-  "timestamp": 1635980695,
+  "timestamp": 1635980695000,
   "height": 1604,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/1603.json
+++ b/service/backend/pchain/indexer/testdata/outs/1603.json
@@ -2,7 +2,7 @@
   "id": "2WSa91XbRZ7h1cHvH7Xp5A3o9etXF4bRCEpj8jdhShXF8Jodt7",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "2guuhVtf9anfhF1U5ngbVi4Kf9Wn68N5hguJ4dsDGsFouU9Adb",
-  "timestamp": 1599696000000,
+  "timestamp": 1635980695,
   "height": 1604,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/1603.json
+++ b/service/backend/pchain/indexer/testdata/outs/1603.json
@@ -2,7 +2,7 @@
   "id": "2WSa91XbRZ7h1cHvH7Xp5A3o9etXF4bRCEpj8jdhShXF8Jodt7",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "2guuhVtf9anfhF1U5ngbVi4Kf9Wn68N5hguJ4dsDGsFouU9Adb",
-  "timestamp": 1635980695000,
+  "timestamp": 1599696000000,
   "height": 1604,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/173.json
+++ b/service/backend/pchain/indexer/testdata/outs/173.json
@@ -2,7 +2,7 @@
   "id": "yGfD3hSJBAynfRW2BpVfNKFMVmJ7Zn1ZQrMzyraU3G8FeLJ8k",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "vWVBLVyPubQkodeHPksSJvF6BpS1SLZuEjg7yskifdzUiXu34",
-  "timestamp": 1635980695,
+  "timestamp": 1635980695000,
   "height": 174,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/173.json
+++ b/service/backend/pchain/indexer/testdata/outs/173.json
@@ -2,7 +2,7 @@
   "id": "yGfD3hSJBAynfRW2BpVfNKFMVmJ7Zn1ZQrMzyraU3G8FeLJ8k",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "vWVBLVyPubQkodeHPksSJvF6BpS1SLZuEjg7yskifdzUiXu34",
-  "timestamp": 1599696000000,
+  "timestamp": 1635980695,
   "height": 174,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/173.json
+++ b/service/backend/pchain/indexer/testdata/outs/173.json
@@ -2,7 +2,7 @@
   "id": "yGfD3hSJBAynfRW2BpVfNKFMVmJ7Zn1ZQrMzyraU3G8FeLJ8k",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "vWVBLVyPubQkodeHPksSJvF6BpS1SLZuEjg7yskifdzUiXu34",
-  "timestamp": 1635980695000,
+  "timestamp": 1599696000000,
   "height": 174,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/2.json
+++ b/service/backend/pchain/indexer/testdata/outs/2.json
@@ -2,7 +2,7 @@
   "id": "2SqWZicfDEQhebMA7Ab3W9uLHiBv2eMNwQ3w9LSbymCuARiWTZ",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "2peK2rrira1UUdFuLWZTMHFdGe3JY8sQeKLfPj5jhPdK8mMAcJ",
-  "timestamp": 1635980695000,
+  "timestamp": 1599696000000,
   "height": 3,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/2.json
+++ b/service/backend/pchain/indexer/testdata/outs/2.json
@@ -2,7 +2,7 @@
   "id": "2SqWZicfDEQhebMA7Ab3W9uLHiBv2eMNwQ3w9LSbymCuARiWTZ",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "2peK2rrira1UUdFuLWZTMHFdGe3JY8sQeKLfPj5jhPdK8mMAcJ",
-  "timestamp": 1599696000000,
+  "timestamp": 1635980695,
   "height": 3,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/2.json
+++ b/service/backend/pchain/indexer/testdata/outs/2.json
@@ -2,7 +2,7 @@
   "id": "2SqWZicfDEQhebMA7Ab3W9uLHiBv2eMNwQ3w9LSbymCuARiWTZ",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "2peK2rrira1UUdFuLWZTMHFdGe3JY8sQeKLfPj5jhPdK8mMAcJ",
-  "timestamp": 1635980695,
+  "timestamp": 1635980695000,
   "height": 3,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/211277.json
+++ b/service/backend/pchain/indexer/testdata/outs/211277.json
@@ -2,7 +2,7 @@
   "id": "arnyzsE9uXJcmFPLwULyYbjUraCvAWbJ3LC6HiJLTA2spD8Eg",
   "type": "*blocks.ApricotStandardBlock",
   "parent": "aA2ucjyrYR6QscaqANKUaUMuMmH4egHCqk987F96kxzSZsnv2",
-  "timestamp": 1635980839,
+  "timestamp": 1635980839000,
   "height": 211278,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/211277.json
+++ b/service/backend/pchain/indexer/testdata/outs/211277.json
@@ -2,7 +2,7 @@
   "id": "arnyzsE9uXJcmFPLwULyYbjUraCvAWbJ3LC6HiJLTA2spD8Eg",
   "type": "*blocks.ApricotStandardBlock",
   "parent": "aA2ucjyrYR6QscaqANKUaUMuMmH4egHCqk987F96kxzSZsnv2",
-  "timestamp": 1635980839000,
+  "timestamp": 1599696000000,
   "height": 211278,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/211277.json
+++ b/service/backend/pchain/indexer/testdata/outs/211277.json
@@ -2,7 +2,7 @@
   "id": "arnyzsE9uXJcmFPLwULyYbjUraCvAWbJ3LC6HiJLTA2spD8Eg",
   "type": "*blocks.ApricotStandardBlock",
   "parent": "aA2ucjyrYR6QscaqANKUaUMuMmH4egHCqk987F96kxzSZsnv2",
-  "timestamp": 1599696000000,
+  "timestamp": 1635980839,
   "height": 211278,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/211333.json
+++ b/service/backend/pchain/indexer/testdata/outs/211333.json
@@ -2,7 +2,7 @@
   "id": "VjXMGrfyxyLZ4GGs3VC5H6mzteQtGVLZpkUs1dwFQnKJRawGt",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "2JxSSBZAQLj8M6oBdUp129J6KSRDFcsyT6GP5k741qNJx6GDNd",
-  "timestamp": 1635980839000,
+  "timestamp": 1599696000000,
   "height": 211334,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/211333.json
+++ b/service/backend/pchain/indexer/testdata/outs/211333.json
@@ -2,7 +2,7 @@
   "id": "VjXMGrfyxyLZ4GGs3VC5H6mzteQtGVLZpkUs1dwFQnKJRawGt",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "2JxSSBZAQLj8M6oBdUp129J6KSRDFcsyT6GP5k741qNJx6GDNd",
-  "timestamp": 1635980839,
+  "timestamp": 1635980839000,
   "height": 211334,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/211333.json
+++ b/service/backend/pchain/indexer/testdata/outs/211333.json
@@ -2,7 +2,7 @@
   "id": "VjXMGrfyxyLZ4GGs3VC5H6mzteQtGVLZpkUs1dwFQnKJRawGt",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "2JxSSBZAQLj8M6oBdUp129J6KSRDFcsyT6GP5k741qNJx6GDNd",
-  "timestamp": 1599696000000,
+  "timestamp": 1635980839,
   "height": 211334,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/382.json
+++ b/service/backend/pchain/indexer/testdata/outs/382.json
@@ -2,7 +2,7 @@
   "id": "2BZD8LSEnArSNwiE74usRGKihA6yDnLwZdGXe1yEfMxwpBFdZB",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "BrPKVKyqobPfk7hZDFeMy4dpi7KFCFonTjgYN1LT5DA7AFaTN",
-  "timestamp": 1635980695000,
+  "timestamp": 1599696000000,
   "height": 383,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/382.json
+++ b/service/backend/pchain/indexer/testdata/outs/382.json
@@ -2,7 +2,7 @@
   "id": "2BZD8LSEnArSNwiE74usRGKihA6yDnLwZdGXe1yEfMxwpBFdZB",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "BrPKVKyqobPfk7hZDFeMy4dpi7KFCFonTjgYN1LT5DA7AFaTN",
-  "timestamp": 1599696000000,
+  "timestamp": 1635980695,
   "height": 383,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/382.json
+++ b/service/backend/pchain/indexer/testdata/outs/382.json
@@ -2,7 +2,7 @@
   "id": "2BZD8LSEnArSNwiE74usRGKihA6yDnLwZdGXe1yEfMxwpBFdZB",
   "type": "*blocks.ApricotProposalBlock",
   "parent": "BrPKVKyqobPfk7hZDFeMy4dpi7KFCFonTjgYN1LT5DA7AFaTN",
-  "timestamp": 1635980695,
+  "timestamp": 1635980695000,
   "height": 383,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/48.json
+++ b/service/backend/pchain/indexer/testdata/outs/48.json
@@ -2,7 +2,7 @@
   "id": "2UqBDUJMHRGPxS78watLZqpqFaCtM3f5SuoxPjfSbNGATk3j66",
   "type": "*blocks.ApricotAbortBlock",
   "parent": "2nxpSHKxf7PoKRvWgXD9k6uqDfHeEaK5uS6x7eDBFJy6Kt6ic6",
-  "timestamp": 1635980695000,
+  "timestamp": 1599696000000,
   "height": 49,
   "transactions": [],
   "proposer": {

--- a/service/backend/pchain/indexer/testdata/outs/48.json
+++ b/service/backend/pchain/indexer/testdata/outs/48.json
@@ -2,7 +2,7 @@
   "id": "2UqBDUJMHRGPxS78watLZqpqFaCtM3f5SuoxPjfSbNGATk3j66",
   "type": "*blocks.ApricotAbortBlock",
   "parent": "2nxpSHKxf7PoKRvWgXD9k6uqDfHeEaK5uS6x7eDBFJy6Kt6ic6",
-  "timestamp": 1599696000000,
+  "timestamp": 1635980695,
   "height": 49,
   "transactions": [],
   "proposer": {

--- a/service/backend/pchain/indexer/testdata/outs/48.json
+++ b/service/backend/pchain/indexer/testdata/outs/48.json
@@ -2,7 +2,7 @@
   "id": "2UqBDUJMHRGPxS78watLZqpqFaCtM3f5SuoxPjfSbNGATk3j66",
   "type": "*blocks.ApricotAbortBlock",
   "parent": "2nxpSHKxf7PoKRvWgXD9k6uqDfHeEaK5uS6x7eDBFJy6Kt6ic6",
-  "timestamp": 1635980695,
+  "timestamp": 1635980695000,
   "height": 49,
   "transactions": [],
   "proposer": {

--- a/service/backend/pchain/indexer/testdata/outs/5981.json
+++ b/service/backend/pchain/indexer/testdata/outs/5981.json
@@ -2,7 +2,7 @@
   "id": "2jhYxP7xDVi3yb7o4WHxPNKxuCHVBqhsMwf6DqsNG452sDDF1g",
   "type": "*blocks.ApricotStandardBlock",
   "parent": "22h1eU6hUa2hubPAG26ix5zkE6SB7nyFjrv9y6i7tMgicD6jjr",
-  "timestamp": 1635980696000,
+  "timestamp": 1599696000000,
   "height": 5982,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/5981.json
+++ b/service/backend/pchain/indexer/testdata/outs/5981.json
@@ -2,7 +2,7 @@
   "id": "2jhYxP7xDVi3yb7o4WHxPNKxuCHVBqhsMwf6DqsNG452sDDF1g",
   "type": "*blocks.ApricotStandardBlock",
   "parent": "22h1eU6hUa2hubPAG26ix5zkE6SB7nyFjrv9y6i7tMgicD6jjr",
-  "timestamp": 1599696000000,
+  "timestamp": 1635980696,
   "height": 5982,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/5981.json
+++ b/service/backend/pchain/indexer/testdata/outs/5981.json
@@ -2,7 +2,7 @@
   "id": "2jhYxP7xDVi3yb7o4WHxPNKxuCHVBqhsMwf6DqsNG452sDDF1g",
   "type": "*blocks.ApricotStandardBlock",
   "parent": "22h1eU6hUa2hubPAG26ix5zkE6SB7nyFjrv9y6i7tMgicD6jjr",
-  "timestamp": 1635980696,
+  "timestamp": 1635980696000,
   "height": 5982,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/8.json
+++ b/service/backend/pchain/indexer/testdata/outs/8.json
@@ -2,7 +2,7 @@
   "id": "2vxS14bQvrcd4JJ1XALpTJE2NGWGAWxsHJexuA5PM4LD4XSi6B",
   "type": "*blocks.ApricotAtomicBlock",
   "parent": "2rjnkz8QvbNM83z7tnCSRZ5NuosUFFhz628ex4MKHrxvyyk5Wc",
-  "timestamp": 1599696000000,
+  "timestamp": 1635980695,
   "height": 9,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/8.json
+++ b/service/backend/pchain/indexer/testdata/outs/8.json
@@ -2,7 +2,7 @@
   "id": "2vxS14bQvrcd4JJ1XALpTJE2NGWGAWxsHJexuA5PM4LD4XSi6B",
   "type": "*blocks.ApricotAtomicBlock",
   "parent": "2rjnkz8QvbNM83z7tnCSRZ5NuosUFFhz628ex4MKHrxvyyk5Wc",
-  "timestamp": 1635980695,
+  "timestamp": 1635980695000,
   "height": 9,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/8.json
+++ b/service/backend/pchain/indexer/testdata/outs/8.json
@@ -2,7 +2,7 @@
   "id": "2vxS14bQvrcd4JJ1XALpTJE2NGWGAWxsHJexuA5PM4LD4XSi6B",
   "type": "*blocks.ApricotAtomicBlock",
   "parent": "2rjnkz8QvbNM83z7tnCSRZ5NuosUFFhz628ex4MKHrxvyyk5Wc",
-  "timestamp": 1635980695000,
+  "timestamp": 1599696000000,
   "height": 9,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/806002.json
+++ b/service/backend/pchain/indexer/testdata/outs/806002.json
@@ -2,7 +2,7 @@
   "id": "2uJMNgW7j7T2Gwp98aHQTgMY47aYC8GZ2hmEGR92k6wM4UCxbC",
   "type": "*blocks.ApricotAtomicBlock",
   "parent": "pgCNn9vUpsy4mkY4i3tnAsgmBsYALw92YsXyXxtPph4QPyUtV",
-  "timestamp": 1632356898000,
+  "timestamp": 1635981783,
   "height": 806003,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/806002.json
+++ b/service/backend/pchain/indexer/testdata/outs/806002.json
@@ -2,7 +2,7 @@
   "id": "2uJMNgW7j7T2Gwp98aHQTgMY47aYC8GZ2hmEGR92k6wM4UCxbC",
   "type": "*blocks.ApricotAtomicBlock",
   "parent": "pgCNn9vUpsy4mkY4i3tnAsgmBsYALw92YsXyXxtPph4QPyUtV",
-  "timestamp": 1635981783000,
+  "timestamp": 1632356898000,
   "height": 806003,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/806002.json
+++ b/service/backend/pchain/indexer/testdata/outs/806002.json
@@ -2,7 +2,7 @@
   "id": "2uJMNgW7j7T2Gwp98aHQTgMY47aYC8GZ2hmEGR92k6wM4UCxbC",
   "type": "*blocks.ApricotAtomicBlock",
   "parent": "pgCNn9vUpsy4mkY4i3tnAsgmBsYALw92YsXyXxtPph4QPyUtV",
-  "timestamp": 1635981783,
+  "timestamp": 1635981783000,
   "height": 806003,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/810424.json
+++ b/service/backend/pchain/indexer/testdata/outs/810424.json
@@ -2,7 +2,7 @@
   "id": "28j2iZ1ASML6PsG53VSjLYC4CCA7xfo4XHAqVbTFrPt9AFb8Me",
   "type": "*blocks.ApricotAtomicBlock",
   "parent": "2CAmmeHJiFxH24BE98SxJKXsg3RMZ2Po6L55goLQU8bxG7Fepi",
-  "timestamp": 1635981793,
+  "timestamp": 1635981793000,
   "height": 810425,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/810424.json
+++ b/service/backend/pchain/indexer/testdata/outs/810424.json
@@ -2,7 +2,7 @@
   "id": "28j2iZ1ASML6PsG53VSjLYC4CCA7xfo4XHAqVbTFrPt9AFb8Me",
   "type": "*blocks.ApricotAtomicBlock",
   "parent": "2CAmmeHJiFxH24BE98SxJKXsg3RMZ2Po6L55goLQU8bxG7Fepi",
-  "timestamp": 1632508114000,
+  "timestamp": 1635981793,
   "height": 810425,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/810424.json
+++ b/service/backend/pchain/indexer/testdata/outs/810424.json
@@ -2,7 +2,7 @@
   "id": "28j2iZ1ASML6PsG53VSjLYC4CCA7xfo4XHAqVbTFrPt9AFb8Me",
   "type": "*blocks.ApricotAtomicBlock",
   "parent": "2CAmmeHJiFxH24BE98SxJKXsg3RMZ2Po6L55goLQU8bxG7Fepi",
-  "timestamp": 1635981793000,
+  "timestamp": 1632508114000,
   "height": 810425,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/911.json
+++ b/service/backend/pchain/indexer/testdata/outs/911.json
@@ -2,7 +2,7 @@
   "id": "2PpHLb6QA8grZaGP9nmQmADjXBetSYyjPRmR9eqoSfo4yinxq",
   "type": "*blocks.ApricotAtomicBlock",
   "parent": "WbVcJjrYR7SMHeymedravjJMi7SgWMtP4HZiVKcwTS8DuvZAX",
-  "timestamp": 1599696000000,
+  "timestamp": 1635980695,
   "height": 912,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/911.json
+++ b/service/backend/pchain/indexer/testdata/outs/911.json
@@ -2,7 +2,7 @@
   "id": "2PpHLb6QA8grZaGP9nmQmADjXBetSYyjPRmR9eqoSfo4yinxq",
   "type": "*blocks.ApricotAtomicBlock",
   "parent": "WbVcJjrYR7SMHeymedravjJMi7SgWMtP4HZiVKcwTS8DuvZAX",
-  "timestamp": 1635980695000,
+  "timestamp": 1599696000000,
   "height": 912,
   "transactions": [
     {

--- a/service/backend/pchain/indexer/testdata/outs/911.json
+++ b/service/backend/pchain/indexer/testdata/outs/911.json
@@ -2,7 +2,7 @@
   "id": "2PpHLb6QA8grZaGP9nmQmADjXBetSYyjPRmR9eqoSfo4yinxq",
   "type": "*blocks.ApricotAtomicBlock",
   "parent": "WbVcJjrYR7SMHeymedravjJMi7SgWMtP4HZiVKcwTS8DuvZAX",
-  "timestamp": 1635980695,
+  "timestamp": 1635980695000,
   "height": 912,
   "transactions": [
     {


### PR DESCRIPTION
This PR contains:

1. Some cleanup of pchain `indexer.Parser`, mostly attributes removal
2. Change in pchain `indexer.Parser` timestamp handling. I chose to pick avalanchego index api timestamp rather than relying on Banff timestamp. The latter would not guarantee a monotonic time, since proposer time is used when banff timestamp is not available. I believe using avalanchego index api timestamp is simpler choice. This time is picked once the avalanchego discovers the block but should be strictly monotonic.
3. Some other minor cleanup, mostly renaming for clarity and some dead code removal.