### PR TITLE
Fill in asset ids for P-chain allocation transaction outputs

### DIFF
--- a/service/backend/pchain/block.go
+++ b/service/backend/pchain/block.go
@@ -410,6 +410,9 @@ func (b *Backend) buildGenesisAllocationTx() (*txs.Tx, error) {
 		}
 
 		outs = append(outs, &avax.TransferableOutput{
+			Asset: avax.Asset{
+				ID: utxo.AssetID(),
+			},
 			Out: &secp256k1fx.TransferOutput{
 				Amt: out.Amount(),
 				OutputOwners: secp256k1fx.OutputOwners{


### PR DESCRIPTION
During block parsing we lookup assets using GetAssetDescription API if the asset id does not match AVAX asset id for the network. Asset ids for the mainnet genesis allocation transaction outputs were not properly set which results in incorrect lookups and request failures. This PR sets them.

### Testing
Parsed Mainnet genesis successfully and ran testnet data validation.