### PR TITLE
Fix c-chain atomic transaction balance currencies

### DIFF
--- a/service/backend/cchainatomictx/account.go
+++ b/service/backend/cchainatomictx/account.go
@@ -3,7 +3,7 @@ package cchainatomictx
 import (
 	"context"
 	"errors"
-	"strconv"
+	"math/big"
 
 	"github.com/ava-labs/avalanchego/api"
 	"github.com/ava-labs/avalanchego/utils/math"
@@ -46,14 +46,10 @@ func (b *Backend) AccountBalance(ctx context.Context, req *types.AccountBalanceR
 		}
 	}
 
+	balance := mapper.AtomicAvaxAmount(new(big.Int).SetUint64(balanceValue))
 	return &types.AccountBalanceResponse{
 		BlockIdentifier: blockIdentifier,
-		Balances: []*types.Amount{
-			{
-				Value:    strconv.FormatUint(balanceValue, 10),
-				Currency: mapper.AvaxCurrency,
-			},
-		},
+		Balances:        []*types.Amount{balance},
 	}, nil
 }
 
@@ -160,15 +156,14 @@ func (b *Backend) processUtxos(sourceChain string, utxos [][]byte) ([]*types.Coi
 			return nil, errUnableToGetUTXOOutput
 		}
 
+		amount := mapper.AtomicAvaxAmount(new(big.Int).SetUint64(transferableOut.Amount()))
+		amount.Metadata = map[string]interface{}{
+			"source_chain": sourceChain,
+		}
+
 		coin := &types.Coin{
 			CoinIdentifier: &types.CoinIdentifier{Identifier: utxo.UTXOID.String()},
-			Amount: &types.Amount{
-				Value:    strconv.FormatUint(transferableOut.Amount(), 10),
-				Currency: mapper.AvaxCurrency,
-				Metadata: map[string]interface{}{
-					"source_chain": sourceChain,
-				},
-			},
+			Amount:         amount,
 		}
 		coins = append(coins, coin)
 	}

--- a/service/backend/cchainatomictx/account_test.go
+++ b/service/backend/cchainatomictx/account_test.go
@@ -66,7 +66,7 @@ func TestAccountBalance(t *testing.T) {
 		evmMock.AssertExpectations(t)
 
 		assert.Equal(t, 1, len(resp.Balances))
-		assert.Equal(t, mapper.AvaxCurrency, resp.Balances[0].Currency)
+		assert.Equal(t, mapper.AtomicAvaxCurrency, resp.Balances[0].Currency)
 		assert.Equal(t, "2500000", resp.Balances[0].Value)
 	})
 }
@@ -112,15 +112,15 @@ func TestAccountCoins(t *testing.T) {
 		assert.Equal(t, 3, len(resp.Coins))
 
 		assert.Equal(t, utxos[0].id, resp.Coins[0].CoinIdentifier.Identifier)
-		assert.Equal(t, mapper.AvaxCurrency, resp.Coins[0].Amount.Currency)
+		assert.Equal(t, mapper.AtomicAvaxCurrency, resp.Coins[0].Amount.Currency)
 		assert.Equal(t, strconv.FormatUint(utxos[0].amount, 10), resp.Coins[0].Amount.Value)
 
 		assert.Equal(t, utxos[3].id, resp.Coins[1].CoinIdentifier.Identifier)
-		assert.Equal(t, mapper.AvaxCurrency, resp.Coins[1].Amount.Currency)
+		assert.Equal(t, mapper.AtomicAvaxCurrency, resp.Coins[1].Amount.Currency)
 		assert.Equal(t, strconv.FormatUint(utxos[3].amount, 10), resp.Coins[1].Amount.Value)
 
 		assert.Equal(t, utxos[1].id, resp.Coins[2].CoinIdentifier.Identifier)
-		assert.Equal(t, mapper.AvaxCurrency, resp.Coins[2].Amount.Currency)
+		assert.Equal(t, mapper.AtomicAvaxCurrency, resp.Coins[2].Amount.Currency)
 		assert.Equal(t, strconv.FormatUint(utxos[1].amount, 10), resp.Coins[2].Amount.Value)
 	})
 }


### PR DESCRIPTION
Amounts are represented in nAVAX using 9 decimals when constructing and parsing C-chain atomic transactions. `/account/balance` and `/account/coins` endpoints are returning amounts in nAVAX with 18 decimals instead of 9. This PR fixes that.