### PR TITLE
Fix Pchain Block ID usage

### DIFF
--- a/client/pchainclient.go
+++ b/client/pchainclient.go
@@ -23,8 +23,9 @@ var _ PChainClient = &pchainClient{}
 // These methods are cloned from the underlying avalanchego client interfaces, following the example of Client interface used to support C-chain operations.
 type PChainClient interface {
 	// indexer.Client methods
+	// Note: we use indexer only to be able to retrieve blocks by height.
+	// Blocks by ID are retrieved via platformVM.GetBlock, thus ignoring the proposerVM part
 	GetContainerByIndex(ctx context.Context, index uint64, options ...rpc.Option) (indexer.Container, error)
-	GetContainerByID(ctx context.Context, containerID ids.ID, options ...rpc.Option) (indexer.Container, error)
 	GetLastAccepted(context.Context, ...rpc.Option) (indexer.Container, error)
 
 	// platformvm.Client methods

--- a/client/pchainclient.go
+++ b/client/pchainclient.go
@@ -25,6 +25,7 @@ type PChainClient interface {
 	// indexer.Client methods
 	// Note: we use indexer only to be able to retrieve blocks by height.
 	// Blocks by ID are retrieved via platformVM.GetBlock, thus ignoring the proposerVM part
+	// and using Pchain Block ID rather than encompassing Snowman++ block ID
 	GetContainerByIndex(ctx context.Context, index uint64, options ...rpc.Option) (indexer.Container, error)
 	GetLastAccepted(context.Context, ...rpc.Option) (indexer.Container, error)
 

--- a/mocks/client/p_chain_client.go
+++ b/mocks/client/p_chain_client.go
@@ -196,34 +196,6 @@ func (_m *PChainClient) GetBlockchainID(_a0 context.Context, _a1 string, _a2 ...
 	return r0, r1
 }
 
-// GetContainerByID provides a mock function with given fields: ctx, containerID, options
-func (_m *PChainClient) GetContainerByID(ctx context.Context, containerID ids.ID, options ...rpc.Option) (indexer.Container, error) {
-	_va := make([]interface{}, len(options))
-	for _i := range options {
-		_va[_i] = options[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, ctx, containerID)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	var r0 indexer.Container
-	if rf, ok := ret.Get(0).(func(context.Context, ids.ID, ...rpc.Option) indexer.Container); ok {
-		r0 = rf(ctx, containerID, options...)
-	} else {
-		r0 = ret.Get(0).(indexer.Container)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, ids.ID, ...rpc.Option) error); ok {
-		r1 = rf(ctx, containerID, options...)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetContainerByIndex provides a mock function with given fields: ctx, index, options
 func (_m *PChainClient) GetContainerByIndex(ctx context.Context, index uint64, options ...rpc.Option) (indexer.Container, error) {
 	_va := make([]interface{}, len(options))

--- a/service/backend/pchain/indexer/parser.go
+++ b/service/backend/pchain/indexer/parser.go
@@ -30,6 +30,10 @@ var (
 )
 
 // Parser defines the interface for a P-chain indexer parser
+// Note: we use indexer just because platformVM does not currently offer a way to retrieve
+// blocks by height. However we do NOT want to use the indexer to retrieve blocks by ID; instead
+// we'll use platformvm.GetBlock api for that. The reason is that we want to use
+// platformVM-level block ID as P-chain blocks identifier rather than proposerVM-level.
 type Parser interface {
 	// GetGenesisBlock parses and returns the Genesis block
 	GetGenesisBlock(ctx context.Context) (*ParsedGenesisBlock, error)
@@ -194,7 +198,7 @@ func (p *parser) parseBlockWithHash(ctx context.Context, hash string) (*ParsedBl
 }
 
 // [parseProposerBlock] parses blocks are retrieved from index api.
-// [parseProposerBlock] tries to parse block asProposerVM block first.
+// [parseProposerBlock] tries to parse block as ProposerVM block first.
 // In case of failure, it tries to parse it as a pre-proposerVM block.
 func (p *parser) parseProposerBlock(blkBytes []byte) (*ParsedBlock, error) {
 	pChainBlkBytes := blkBytes


### PR DESCRIPTION
Rosetta wants to use PChain block IDs as blocks identifiers and not proposerVM block IDs. Hence we want to forbid getting blocks by ID from indexer, which would assume the input hash is a proposerVM blockID and we use platformvm.GetBlock in such case