### PR TITLE
Disable p-chain indexer related calls in offline mode

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -136,10 +136,14 @@ func main() {
 	}
 
 	pChainClient := client.NewPChainClient(context.Background(), cfg.RPCBaseURL, cfg.IndexerBaseURL)
-	pIndexerParser, err := indexer.NewParser(pChainClient)
-	if err != nil {
-		log.Fatal("unable to initialize p-chain indexer parser:", err)
+	var pIndexerParser indexer.Parser
+	if cfg.Mode == service.ModeOnline {
+		pIndexerParser, err = indexer.NewParser(pChainClient)
+		if err != nil {
+			log.Fatal("unable to initialize p-chain indexer parser:", err)
+		}
 	}
+
 	pChainBackend, err := pchain.NewBackend(cfg.Mode, pChainClient, pIndexerParser, avaxAssetID, networkP)
 	if err != nil {
 		log.Fatal("unable to initialize p-chain backend:", err)

--- a/service/backend/pchain/backend.go
+++ b/service/backend/pchain/backend.go
@@ -48,7 +48,7 @@ func NewBackend(
 	assetID ids.ID,
 	networkIdentifier *types.NetworkIdentifier,
 ) (*Backend, error) {
-	genHandler, err := newGenesisHandler(indexerParser)
+	genHandler, err := newGenesisHandler(nodeMode, indexerParser)
 	if err != nil {
 		return nil, err
 	}

--- a/service/backend/pchain/genesis_handler.go
+++ b/service/backend/pchain/genesis_handler.go
@@ -3,7 +3,6 @@ package pchain
 import (
 	"context"
 
-	"github.com/ava-labs/avalanche-rosetta/service/backend/pchain/indexer"
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
@@ -11,6 +10,9 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/coinbase/rosetta-sdk-go/types"
+
+	"github.com/ava-labs/avalanche-rosetta/service"
+	"github.com/ava-labs/avalanche-rosetta/service/backend/pchain/indexer"
 )
 
 var _ genesisHandler = &gHandler{}
@@ -25,7 +27,7 @@ type genesisHandler interface {
 	buildGenesisAllocationTx() (*txs.Tx, error)
 }
 
-func newGenesisHandler(indexerParser indexer.Parser) (genesisHandler, error) {
+func newGenesisHandler(nodeMode string, indexerParser indexer.Parser) (genesisHandler, error) {
 	gh := &gHandler{
 		indexerParser: indexerParser,
 
@@ -35,7 +37,14 @@ func newGenesisHandler(indexerParser indexer.Parser) (genesisHandler, error) {
 		genesisCodec: blocks.GenesisCodec,
 	}
 
-	return gh, gh.loadGenesisBlk()
+	var err error
+
+	// Initializing genesis block from indexer only in online mode
+	if nodeMode == service.ModeOnline {
+		err = gh.loadGenesisBlk()
+	}
+
+	return gh, err
 }
 
 type gHandler struct {


### PR DESCRIPTION
During startup, indexer parser calls info and indexer endpoints to figure out network id and genesis block. Adding online mode checks to prevent these calls in the offline mode.