### PR TITLE
Get network name fix

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ava-labs/avalanchego/api"
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/utils/rpc"
 	ethtypes "github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/interfaces"
 	"github.com/ava-labs/coreth/plugin/evm"
@@ -21,11 +20,7 @@ var _ Client = &client{}
 
 type Client interface {
 	// info.Client methods
-	IsBootstrapped(context.Context, string, ...rpc.Option) (bool, error)
-	GetNetworkName(context.Context, ...rpc.Option) (string, error)
-	Peers(context.Context, ...rpc.Option) ([]info.Peer, error)
-	GetNetworkID(context.Context, ...rpc.Option) (uint32, error)
-	GetBlockchainID(context.Context, string, ...rpc.Option) (ids.ID, error)
+	InfoClient
 
 	ChainID(context.Context) (*big.Int, error)
 	BlockByHash(context.Context, ethcommon.Hash) (*ethtypes.Block, error)

--- a/client/info_client.go
+++ b/client/info_client.go
@@ -1,0 +1,19 @@
+package client
+
+import (
+	"context"
+
+	"github.com/ava-labs/avalanchego/api/info"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/rpc"
+)
+
+// InfoClient collects all Avalanchego info.Client methods common
+// to Rosetta Clients
+type InfoClient interface {
+	GetNetworkName(context.Context, ...rpc.Option) (string, error)
+	GetNetworkID(context.Context, ...rpc.Option) (uint32, error)
+	GetBlockchainID(context.Context, string, ...rpc.Option) (ids.ID, error)
+	IsBootstrapped(context.Context, string, ...rpc.Option) (bool, error)
+	Peers(context.Context, ...rpc.Option) ([]info.Peer, error)
+}

--- a/client/pchainclient.go
+++ b/client/pchainclient.go
@@ -22,6 +22,11 @@ var _ PChainClient = &pchainClient{}
 //
 // These methods are cloned from the underlying avalanchego client interfaces, following the example of Client interface used to support C-chain operations.
 type PChainClient interface {
+	// info.Client methods
+	InfoClient
+	GetNodeID(context.Context, ...rpc.Option) (ids.NodeID, *signer.ProofOfPossession, error)
+	GetTxFee(context.Context, ...rpc.Option) (*info.GetTxFeeResponse, error)
+
 	// indexer.Client methods
 	// Note: we use indexer only to be able to retrieve blocks by height.
 	// Blocks by ID are retrieved via platformVM.GetBlock, thus ignoring the proposerVM part
@@ -57,14 +62,6 @@ type PChainClient interface {
 
 	// avm.Client methods
 	GetAssetDescription(ctx context.Context, assetID string, options ...rpc.Option) (*avm.GetAssetDescriptionReply, error)
-
-	// info.Client methods
-	IsBootstrapped(context.Context, string, ...rpc.Option) (bool, error)
-	Peers(context.Context, ...rpc.Option) ([]info.Peer, error)
-	GetNodeID(context.Context, ...rpc.Option) (ids.NodeID, *signer.ProofOfPossession, error)
-	GetNetworkID(context.Context, ...rpc.Option) (uint32, error)
-	GetBlockchainID(context.Context, string, ...rpc.Option) (ids.ID, error)
-	GetTxFee(context.Context, ...rpc.Option) (*info.GetTxFeeResponse, error)
 }
 
 type (

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -78,6 +78,14 @@ func (c *config) validate() error {
 		return errInvalidMode
 	}
 
+	if c.Mode == service.ModeOffline && c.ChainID == 0 {
+		return errors.New("chainID must be configured when offline mode is selected")
+	}
+
+	if c.NetworkName == "" {
+		return errors.New("network name not provided")
+	}
+
 	if c.GenesisBlockHash == "" {
 		return errGenesisBlockRequired
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -204,10 +204,9 @@ func main() {
 
 func validateNetworkName(cfg *config, cChainClient client.Client) error {
 	if cfg.Mode == service.ModeOffline {
-		if cfg.NetworkName != "" {
+		if cfg.NetworkName == "" {
 			return fmt.Errorf("network name is not provided, can't fetch network name in offline mode")
 		}
-		cfg.NetworkName = ""
 
 		return nil
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"math/big"
@@ -84,11 +83,6 @@ func main() {
 
 	if cfg.ChainID == 0 {
 		log.Println("chain id is not provided, fetching from rpc...")
-
-		if cfg.Mode == service.ModeOffline {
-			log.Fatal("cant fetch chain id in offline mode")
-		}
-
 		chainID, err := cChainClient.ChainID(context.Background())
 		if err != nil {
 			log.Fatal("cant fetch chain id from rpc:", err)
@@ -107,10 +101,6 @@ func main() {
 		AP5Activation = constants.FujiAP5Activation.Uint64()
 	default:
 		log.Fatal("invalid ChainID:", cfg.ChainID)
-	}
-
-	if err := validateNetworkName(cfg, cChainClient); err != nil {
-		log.Fatal("invalid network name:", err)
 	}
 
 	// Note: Rosetta is currently configure with capitalized NetworkNames
@@ -199,23 +189,6 @@ func main() {
 	log.Printf("starting rosetta server at %s\n", cfg.ListenAddr)
 
 	log.Fatal(http.ListenAndServe(cfg.ListenAddr, router))
-}
-
-func validateNetworkName(cfg *config, cChainClient client.Client) error {
-	if cfg.Mode == service.ModeOffline {
-		if cfg.NetworkName != "" {
-			return fmt.Errorf("network name is not provided, can't fetch network name in offline mode")
-		}
-
-		return nil
-	}
-
-	// Note: we don't check here whether cfg.NetworkName matches the name exposed by
-	// avalanchego via client.GetNetworkName. This is because we are not guaranteed
-	// that avalanchego node is ready to serve API requests when Rosetta is started.
-	// So we trust the configure network name for now and defer checks to specif
-	// requests.
-	return nil
 }
 
 func configureRouter(

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"math/big"
 	"net/http"
-	"strings"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/coinbase/rosetta-sdk-go/asserter"
@@ -204,31 +203,18 @@ func main() {
 
 func validateNetworkName(cfg *config, cChainClient client.Client) error {
 	if cfg.Mode == service.ModeOffline {
-		if cfg.NetworkName == "" {
+		if cfg.NetworkName != "" {
 			return fmt.Errorf("network name is not provided, can't fetch network name in offline mode")
 		}
 
 		return nil
 	}
 
-	log.Println("fetching network name from rpc...")
-	networkName, err := cChainClient.GetNetworkName(context.Background())
-	if err != nil {
-		return fmt.Errorf("cant fetch network name: %w", err)
-	}
-
-	if cfg.NetworkName == "" {
-		log.Printf("network name is not provided, set to %s", networkName)
-		cfg.NetworkName = networkName
-		return nil
-	}
-
-	if strings.ToLower(cfg.NetworkName) != networkName {
-		return fmt.Errorf("configured network name %s does not match with avalanche go client one %s",
-			cfg.NetworkName,
-			networkName,
-		)
-	}
+	// Note: we don't check here whether cfg.NetworkName matches the name exposed by
+	// avalanchego via client.GetNetworkName. This is because we are not guaranteed
+	// that avalanchego node is ready to serve API requests when Rosetta is started.
+	// So we trust the configure network name for now and defer checks to specif
+	// requests.
 	return nil
 }
 

--- a/mocks/client/p_chain_client.go
+++ b/mocks/client/p_chain_client.go
@@ -315,6 +315,34 @@ func (_m *PChainClient) GetNetworkID(_a0 context.Context, _a1 ...rpc.Option) (ui
 	return r0, r1
 }
 
+// GetNetworkName provides a mock function with given fields: _a0, _a1
+func (_m *PChainClient) GetNetworkName(_a0 context.Context, _a1 ...rpc.Option) (string, error) {
+	_va := make([]interface{}, len(_a1))
+	for _i := range _a1 {
+		_va[_i] = _a1[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(context.Context, ...rpc.Option) string); ok {
+		r0 = rf(_a0, _a1...)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, ...rpc.Option) error); ok {
+		r1 = rf(_a0, _a1...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetNodeID provides a mock function with given fields: _a0, _a1
 func (_m *PChainClient) GetNodeID(_a0 context.Context, _a1 ...rpc.Option) (ids.NodeID, *signer.ProofOfPossession, error) {
 	_va := make([]interface{}, len(_a1))

--- a/service/backend/pchain/backend.go
+++ b/service/backend/pchain/backend.go
@@ -53,7 +53,7 @@ func NewBackend(
 		return nil, err
 	}
 
-	backEnd := &Backend{
+	b := &Backend{
 		genesisHandler:   genHandler,
 		fac:              &crypto.FactorySECP256K1R{},
 		networkID:        networkIdentifier,
@@ -67,24 +67,24 @@ func NewBackend(
 	}
 
 	if nodeMode == service.ModeOnline {
-		if err := backEnd.initChainIDs(); err != nil {
+		if err := b.initChainIDs(); err != nil {
+			return nil, err
+		}
+
+		if b.networkHRP, err = mapper.GetHRP(b.networkID); err != nil {
 			return nil, err
 		}
 	}
 
-	backEnd.networkHRP, err = mapper.GetHRP(networkIdentifier)
-	if err != nil {
-		return nil, err
+	b.txParserCfg = pmapper.TxParserConfig{
+		IsConstruction: false,
+		Hrp:            b.networkHRP,
+		ChainIDs:       b.chainIDs,
+		AvaxAssetID:    b.avaxAssetID,
+		PChainClient:   b.pClient,
 	}
 
-	backEnd.txParserCfg = pmapper.TxParserConfig{
-		IsConstruction: false,
-		Hrp:            backEnd.networkHRP,
-		ChainIDs:       backEnd.chainIDs,
-		AvaxAssetID:    backEnd.avaxAssetID,
-		PChainClient:   backEnd.pClient,
-	}
-	return backEnd, err
+	return b, nil
 }
 
 // ShouldHandleRequest returns whether a given request should be handled by this backend


### PR DESCRIPTION
When running Rosetta we cannot take for granted that avalanchego node backing Rosetta server is ready when server is started.
I did not take this into account and mistakenly try and call GetNetworkName immediately upon startup.
This PR fixes the issue