### PR TITLE
Lazy inits

### DIFF
--- a/service/backend/pchain/account_test.go
+++ b/service/backend/pchain/account_test.go
@@ -43,8 +43,6 @@ var (
 func TestAccountBalance(t *testing.T) {
 	ctx := context.Background()
 	pChainMock := &mocks.PChainClient{}
-	pChainMock.Mock.On("GetBlockchainID", ctx, constants.CChain.String()).Return(ids.ID{'C'}, nil)
-	pChainMock.Mock.On("GetBlockchainID", ctx, constants.XChain.String()).Return(ids.ID{'X'}, nil)
 	parserMock := &idxmocks.Parser{}
 	parserMock.Mock.On("GetGenesisBlock", ctx).Return(dummyGenesis, nil)
 	parserMock.Mock.On("ParseNonGenesisBlock", ctx, "", blockHeight).Return(parsedBlock, nil)
@@ -204,8 +202,6 @@ func TestAccountBalance(t *testing.T) {
 func TestAccountCoins(t *testing.T) {
 	ctx := context.Background()
 	pChainMock := &mocks.PChainClient{}
-	pChainMock.Mock.On("GetBlockchainID", ctx, constants.CChain.String()).Return(ids.ID{'C'}, nil)
-	pChainMock.Mock.On("GetBlockchainID", ctx, constants.XChain.String()).Return(ids.ID{'X'}, nil)
 	parserMock := &idxmocks.Parser{}
 	parserMock.Mock.On("GetGenesisBlock", ctx).Return(dummyGenesis, nil)
 	parserMock.Mock.On("ParseNonGenesisBlock", ctx, "", blockHeight).Return(parsedBlock, nil)

--- a/service/backend/pchain/backend.go
+++ b/service/backend/pchain/backend.go
@@ -1,8 +1,6 @@
 package pchain
 
 import (
-	"context"
-
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/crypto"
@@ -113,27 +111,6 @@ func (b *Backend) ShouldHandleRequest(req interface{}) bool {
 	}
 
 	return false
-}
-
-func lazyInitChainIDs(pClient client.PChainClient) (map[ids.ID]constants.ChainIDAlias, error) {
-	chainIDs := map[ids.ID]constants.ChainIDAlias{
-		ids.Empty: constants.PChain,
-	}
-
-	ctx := context.Background()
-	cChainID, err := pClient.GetBlockchainID(ctx, constants.CChain.String())
-	if err != nil {
-		return nil, err
-	}
-	chainIDs[cChainID] = constants.CChain
-
-	xChainID, err := pClient.GetBlockchainID(ctx, constants.XChain.String())
-	if err != nil {
-		return nil, err
-	}
-	chainIDs[xChainID] = constants.XChain
-
-	return chainIDs, nil
 }
 
 // isPChain checks network identifier to make sure sub-network identifier set to "P"

--- a/service/backend/pchain/backend.go
+++ b/service/backend/pchain/backend.go
@@ -45,10 +45,7 @@ func NewBackend(
 	assetID ids.ID,
 	networkIdentifier *types.NetworkIdentifier,
 ) (*Backend, error) {
-	genHandler, err := newGenesisHandler(nodeMode, indexerParser)
-	if err != nil {
-		return nil, err
-	}
+	genHandler := newGenesisHandler(nodeMode, indexerParser)
 
 	b := &Backend{
 		genesisHandler:   genHandler,
@@ -63,6 +60,7 @@ func NewBackend(
 	}
 
 	if nodeMode == service.ModeOnline {
+		var err error
 		if b.networkHRP, err = mapper.GetHRP(b.networkID); err != nil {
 			return nil, err
 		}

--- a/service/backend/pchain/construction_test.go
+++ b/service/backend/pchain/construction_test.go
@@ -185,8 +185,6 @@ func TestExportTxConstruction(t *testing.T) {
 
 	ctx := context.Background()
 	clientMock := &mocks.PChainClient{}
-	clientMock.Mock.On("GetBlockchainID", ctx, constants.CChain.String()).Return(cChainID, nil)
-	clientMock.Mock.On("GetBlockchainID", ctx, constants.XChain.String()).Return(ids.ID{'X'}, nil)
 	parserMock := &idxmocks.Parser{}
 	parserMock.Mock.On("GetGenesisBlock", ctx).Return(dummyGenesis, nil)
 	backend, err := NewBackend(service.ModeOnline, clientMock, parserMock, avaxAssetID, pChainNetworkIdentifier)
@@ -401,8 +399,6 @@ func TestImportTxConstruction(t *testing.T) {
 
 	ctx := context.Background()
 	clientMock := &mocks.PChainClient{}
-	clientMock.Mock.On("GetBlockchainID", ctx, constants.CChain.String()).Return(cChainID, nil)
-	clientMock.Mock.On("GetBlockchainID", ctx, constants.XChain.String()).Return(ids.ID{'X'}, nil)
 	parserMock := &idxmocks.Parser{}
 	parserMock.Mock.On("GetGenesisBlock", ctx).Return(dummyGenesis, nil)
 	backend, err := NewBackend(service.ModeOnline, clientMock, parserMock, avaxAssetID, pChainNetworkIdentifier)
@@ -640,8 +636,6 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 
 	ctx := context.Background()
 	clientMock := &mocks.PChainClient{}
-	clientMock.Mock.On("GetBlockchainID", ctx, constants.CChain.String()).Return(cChainID, nil)
-	clientMock.Mock.On("GetBlockchainID", ctx, constants.XChain.String()).Return(ids.ID{'X'}, nil)
 	parserMock := &idxmocks.Parser{}
 	parserMock.Mock.On("GetGenesisBlock", ctx).Return(dummyGenesis, nil)
 	backend, err := NewBackend(service.ModeOnline, clientMock, parserMock, avaxAssetID, pChainNetworkIdentifier)
@@ -874,8 +868,8 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 
 	ctx := context.Background()
 	clientMock := &mocks.PChainClient{}
-	clientMock.Mock.On("GetBlockchainID", ctx, constants.CChain.String()).Return(cChainID, nil)
-	clientMock.Mock.On("GetBlockchainID", ctx, constants.XChain.String()).Return(ids.ID{'X'}, nil)
+	// clientMock.Mock.On("GetBlockchainID", ctx, constants.CChain.String()).Return(cChainID, nil)
+	// clientMock.Mock.On("GetBlockchainID", ctx, constants.XChain.String()).Return(ids.ID{'X'}, nil)
 	parserMock := &idxmocks.Parser{}
 	parserMock.Mock.On("GetGenesisBlock", ctx).Return(dummyGenesis, nil)
 	backend, err := NewBackend(service.ModeOnline, clientMock, parserMock, avaxAssetID, pChainNetworkIdentifier)

--- a/service/backend/pchain/construction_test.go
+++ b/service/backend/pchain/construction_test.go
@@ -868,8 +868,6 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 
 	ctx := context.Background()
 	clientMock := &mocks.PChainClient{}
-	// clientMock.Mock.On("GetBlockchainID", ctx, constants.CChain.String()).Return(cChainID, nil)
-	// clientMock.Mock.On("GetBlockchainID", ctx, constants.XChain.String()).Return(ids.ID{'X'}, nil)
 	parserMock := &idxmocks.Parser{}
 	parserMock.Mock.On("GetGenesisBlock", ctx).Return(dummyGenesis, nil)
 	backend, err := NewBackend(service.ModeOnline, clientMock, parserMock, avaxAssetID, pChainNetworkIdentifier)

--- a/service/backend/pchain/genesis_handler.go
+++ b/service/backend/pchain/genesis_handler.go
@@ -18,7 +18,7 @@ import (
 var _ genesisHandler = &gHandler{}
 
 type genesisHandler interface {
-	isGenesisBlockRequest(index int64, hash string) bool
+	isGenesisBlockRequest(index int64, hash string) (bool, error)
 	getGenesisBlock() *indexer.ParsedGenesisBlock
 	getGenesisIdentifier() *types.BlockIdentifier
 
@@ -41,51 +41,71 @@ func newGenesisHandler(nodeMode string, indexerParser indexer.Parser) (genesisHa
 
 	// Initializing genesis block from indexer only in online mode
 	if nodeMode == service.ModeOnline {
-		err = gh.loadGenesisBlk()
+		err = gh.lazyLoadGenesisBlk()
 	}
 
 	return gh, err
 }
 
 type gHandler struct {
-	indexerParser     indexer.Parser
-	genesisCodec      codec.Manager
+	indexerParser indexer.Parser
+	genesisCodec  codec.Manager
+
+	// genesisBlk is lazily initialized, as soon as
+	// pChainClient is ready to serve requests
+	genesisBlkFetched bool
 	genesisBlk        *indexer.ParsedGenesisBlock
 	genesisIdentifier *types.BlockIdentifier
-	allocationTx      *txs.Tx
+
+	allocationTx *txs.Tx
 }
 
-func (gh *gHandler) loadGenesisBlk() error {
+func (gh *gHandler) lazyLoadGenesisBlk() error {
+	if gh.genesisBlkFetched {
+		return nil // already initialized
+	}
+
 	genesisBlk, err := gh.indexerParser.GetGenesisBlock(context.Background())
-	if err != nil {
-		return err
+	if err == nil {
+		gh.genesisBlkFetched = true
+		gh.genesisBlk = genesisBlk
+		gh.genesisIdentifier = &types.BlockIdentifier{
+			Index: int64(genesisBlk.Height),
+			Hash:  genesisBlk.BlockID.String(),
+		}
 	}
-	gh.genesisBlk = genesisBlk
-	gh.genesisIdentifier = &types.BlockIdentifier{
-		Index: int64(genesisBlk.Height),
-		Hash:  genesisBlk.BlockID.String(),
-	}
+
 	return nil
 }
 
-func (gh *gHandler) isGenesisBlockRequest(index int64, hash string) bool {
+func (gh *gHandler) isGenesisBlockRequest(index int64, hash string) (bool, error) {
+	if err := gh.lazyLoadGenesisBlk(); err != nil {
+		return false, err
+	}
+
 	// if hash is provided, make sure it matches genesis block hash
 	if hash != "" {
-		return hash == gh.genesisBlk.BlockID.String()
+		return hash == gh.genesisBlk.BlockID.String(), nil
 	}
 
 	// if hash is omitted, check if the height matches the genesis block height
-	return index == int64(gh.genesisBlk.Height)
+	return index == int64(gh.genesisBlk.Height), nil
 }
 
+// getGenesisBlock is a simple getter for genesisBlk. It does not check
+// whether genesisBlk has been duly initialized. Check is up to caller
 func (gh *gHandler) getGenesisBlock() *indexer.ParsedGenesisBlock {
 	return gh.genesisBlk
 }
 
+// getGenesisIdentifier is a simple getter for genesisIdentifier. It does not check
+// whether genesisIdentifier has been duly initialized. Check is up to caller
 func (gh *gHandler) getGenesisIdentifier() *types.BlockIdentifier {
 	return gh.genesisIdentifier
 }
 
+// getFullGenesisTxs does not check whether genesis
+// has been duly initialized. Check is up to caller
 func (gh *gHandler) getFullGenesisTxs() ([]*txs.Tx, error) {
 	res := gh.genesisBlk.Txs
 	allocationTx, err := gh.buildGenesisAllocationTx()

--- a/service/backend/pchain/indexer/parser.go
+++ b/service/backend/pchain/indexer/parser.go
@@ -55,11 +55,17 @@ type parser struct {
 	codec        codec.Manager
 	codecVersion uint16
 
-	networkID uint32
-	aliaser   ids.Aliaser
+	// networkID is lazily initiazed, as soon as
+	// pChainClient is ready to serve requests
+	networkIDFetched bool
+	networkID        uint32
+
+	aliaser ids.Aliaser
 }
 
 // NewParser creates a new P-chain indexer parser
+// Note: NewParser should not contain calls to pChainClient as we
+// cannot assume client is ready to serve requests immediately
 func NewParser(pChainClient client.PChainClient) (Parser, error) {
 	aliaser := ids.NewAliaser()
 	err := aliaser.Alias(constants.PlatformChainID, rosConst.PChain.String())
@@ -67,18 +73,34 @@ func NewParser(pChainClient client.PChainClient) (Parser, error) {
 		return nil, err
 	}
 
+	networkIDFetched := false
 	networkID, err := pChainClient.GetNetworkID(context.Background())
-	if err != nil {
-		return nil, err
+	if err == nil {
+		networkIDFetched = true
 	}
 
 	return &parser{
-		pChainClient: pChainClient,
-		codec:        pBlocks.Codec,
-		codecVersion: pBlocks.Version,
-		networkID:    networkID,
-		aliaser:      aliaser,
+		pChainClient:     pChainClient,
+		codec:            pBlocks.Codec,
+		codecVersion:     pBlocks.Version,
+		networkIDFetched: networkIDFetched,
+		networkID:        networkID,
+		aliaser:          aliaser,
 	}, nil
+}
+
+func (p *parser) lazyInitNetworkID(ctx context.Context) error {
+	if p.networkIDFetched {
+		return nil // already inited
+	}
+	networkID, err := p.pChainClient.GetNetworkID(ctx)
+	if err != nil {
+		return err
+	}
+
+	p.networkIDFetched = true
+	p.networkID = networkID
+	return nil
 }
 
 func (p *parser) GetPlatformHeight(ctx context.Context) (uint64, error) {
@@ -97,6 +119,10 @@ func (p *parser) GetPlatformHeight(ctx context.Context) (uint64, error) {
 // GetGenesisBlock should not call the indexer, to ensure backward compatibility with
 // previous installations which do no host a block indexer.
 func (p *parser) GetGenesisBlock(ctx context.Context) (*ParsedGenesisBlock, error) {
+	if err := p.lazyInitNetworkID(ctx); err != nil {
+		return nil, err
+	}
+
 	bytes, _, err := genesis.FromConfig(genesis.GetConfig(p.networkID))
 	if err != nil {
 		return nil, err

--- a/service/backend/pchain/indexer/parser.go
+++ b/service/backend/pchain/indexer/parser.go
@@ -55,7 +55,7 @@ type parser struct {
 	codec        codec.Manager
 	codecVersion uint16
 
-	// networkID is lazily initiazed, as soon as
+	// networkID is lazily initialized, as soon as
 	// pChainClient is ready to serve requests
 	networkIDFetched bool
 	networkID        uint32
@@ -91,7 +91,7 @@ func NewParser(pChainClient client.PChainClient) (Parser, error) {
 
 func (p *parser) lazyInitNetworkID(ctx context.Context) error {
 	if p.networkIDFetched {
-		return nil // already inited
+		return nil // already initialized
 	}
 	networkID, err := p.pChainClient.GetNetworkID(ctx)
 	if err != nil {


### PR DESCRIPTION
Turns out it wasn't only GetNetworkName being called too early in some situations. Other avalanchego calls are issued upon server construction which causes the whole node to fail if avalanche node is not ready to serve requests immediately.
This PR addresses the issue