### PR TITLE
Dropped most lazy inits in favour of Avalanchego codebase methods

### DIFF
--- a/client/info_client.go
+++ b/client/info_client.go
@@ -11,7 +11,6 @@ import (
 // InfoClient collects all Avalanchego info.Client methods common
 // to Rosetta Clients
 type InfoClient interface {
-	GetNetworkName(context.Context, ...rpc.Option) (string, error)
 	GetNetworkID(context.Context, ...rpc.Option) (uint32, error)
 	GetBlockchainID(context.Context, string, ...rpc.Option) (ids.ID, error)
 	IsBootstrapped(context.Context, string, ...rpc.Option) (bool, error)

--- a/client/info_client.go
+++ b/client/info_client.go
@@ -11,7 +11,6 @@ import (
 // InfoClient collects all Avalanchego info.Client methods common
 // to Rosetta Clients
 type InfoClient interface {
-	GetNetworkID(context.Context, ...rpc.Option) (uint32, error)
 	GetBlockchainID(context.Context, string, ...rpc.Option) (ids.ID, error)
 	IsBootstrapped(context.Context, string, ...rpc.Option) (bool, error)
 	Peers(context.Context, ...rpc.Option) ([]info.Peer, error)

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ava-labs/avalanche-rosetta/client"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 	"github.com/ava-labs/avalanche-rosetta/service"
+	"github.com/ava-labs/avalanchego/utils/constants"
 )
 
 var (
@@ -86,6 +87,10 @@ func (c *config) validate() error {
 		return errors.New("network name not provided")
 	}
 
+	if _, err := constants.NetworkID(c.NetworkName); err != nil {
+		return errors.New("network name not mapping to any known network ID")
+	}
+
 	if c.GenesisBlockHash == "" {
 		return errGenesisBlockRequired
 	}
@@ -133,4 +138,10 @@ func (c *config) validateWhitelistOnlyValidErc20s(cli client.Client) error {
 		}
 	}
 	return nil
+}
+
+func (c *config) avalancheNetworkID() uint32 {
+	// error checked in config.validate
+	res, _ := constants.NetworkID(c.NetworkName)
+	return res
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -125,12 +125,9 @@ func main() {
 	}
 
 	pChainClient := client.NewPChainClient(context.Background(), cfg.RPCBaseURL, cfg.IndexerBaseURL)
-	var pIndexerParser indexer.Parser
-	if cfg.Mode == service.ModeOnline {
-		pIndexerParser, err = indexer.NewParser(pChainClient, cfg.avalancheNetworkID())
-		if err != nil {
-			log.Fatal("unable to initialize p-chain indexer parser:", err)
-		}
+	pIndexerParser, err := indexer.NewParser(pChainClient, cfg.avalancheNetworkID())
+	if err != nil {
+		log.Fatal("unable to initialize p-chain indexer parser:", err)
 	}
 
 	pChainBackend, err := pchain.NewBackend(

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -127,18 +127,25 @@ func main() {
 	pChainClient := client.NewPChainClient(context.Background(), cfg.RPCBaseURL, cfg.IndexerBaseURL)
 	var pIndexerParser indexer.Parser
 	if cfg.Mode == service.ModeOnline {
-		pIndexerParser, err = indexer.NewParser(pChainClient)
+		pIndexerParser, err = indexer.NewParser(pChainClient, cfg.avalancheNetworkID())
 		if err != nil {
 			log.Fatal("unable to initialize p-chain indexer parser:", err)
 		}
 	}
 
-	pChainBackend, err := pchain.NewBackend(cfg.Mode, pChainClient, pIndexerParser, avaxAssetID, networkP)
+	pChainBackend, err := pchain.NewBackend(
+		cfg.Mode,
+		pChainClient,
+		pIndexerParser,
+		avaxAssetID,
+		networkP,
+		cfg.avalancheNetworkID(),
+	)
 	if err != nil {
 		log.Fatal("unable to initialize p-chain backend:", err)
 	}
 
-	cChainAtomicTxBackend := cchainatomictx.NewBackend(cChainClient, avaxAssetID)
+	cChainAtomicTxBackend := cchainatomictx.NewBackend(cChainClient, avaxAssetID, cfg.avalancheNetworkID())
 
 	serviceConfig := &service.Config{
 		Mode:               cfg.Mode,

--- a/mocks/client/client.go
+++ b/mocks/client/client.go
@@ -278,34 +278,6 @@ func (_m *Client) GetContractInfo(_a0 common.Address, _a1 bool) (string, uint8, 
 	return r0, r1, r2
 }
 
-// GetNetworkID provides a mock function with given fields: _a0, _a1
-func (_m *Client) GetNetworkID(_a0 context.Context, _a1 ...rpc.Option) (uint32, error) {
-	_va := make([]interface{}, len(_a1))
-	for _i := range _a1 {
-		_va[_i] = _a1[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, _a0)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func(context.Context, ...rpc.Option) uint32); ok {
-		r0 = rf(_a0, _a1...)
-	} else {
-		r0 = ret.Get(0).(uint32)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, ...rpc.Option) error); ok {
-		r1 = rf(_a0, _a1...)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // HeaderByHash provides a mock function with given fields: _a0, _a1
 func (_m *Client) HeaderByHash(_a0 context.Context, _a1 common.Hash) (*types.Header, error) {
 	ret := _m.Called(_a0, _a1)

--- a/mocks/client/client.go
+++ b/mocks/client/client.go
@@ -306,34 +306,6 @@ func (_m *Client) GetNetworkID(_a0 context.Context, _a1 ...rpc.Option) (uint32, 
 	return r0, r1
 }
 
-// GetNetworkName provides a mock function with given fields: _a0, _a1
-func (_m *Client) GetNetworkName(_a0 context.Context, _a1 ...rpc.Option) (string, error) {
-	_va := make([]interface{}, len(_a1))
-	for _i := range _a1 {
-		_va[_i] = _a1[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, _a0)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func(context.Context, ...rpc.Option) string); ok {
-		r0 = rf(_a0, _a1...)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, ...rpc.Option) error); ok {
-		r1 = rf(_a0, _a1...)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // HeaderByHash provides a mock function with given fields: _a0, _a1
 func (_m *Client) HeaderByHash(_a0 context.Context, _a1 common.Hash) (*types.Header, error) {
 	ret := _m.Called(_a0, _a1)

--- a/mocks/client/p_chain_client.go
+++ b/mocks/client/p_chain_client.go
@@ -287,34 +287,6 @@ func (_m *PChainClient) GetLastAccepted(_a0 context.Context, _a1 ...rpc.Option) 
 	return r0, r1, r2
 }
 
-// GetNetworkID provides a mock function with given fields: _a0, _a1
-func (_m *PChainClient) GetNetworkID(_a0 context.Context, _a1 ...rpc.Option) (uint32, error) {
-	_va := make([]interface{}, len(_a1))
-	for _i := range _a1 {
-		_va[_i] = _a1[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, _a0)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func(context.Context, ...rpc.Option) uint32); ok {
-		r0 = rf(_a0, _a1...)
-	} else {
-		r0 = ret.Get(0).(uint32)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, ...rpc.Option) error); ok {
-		r1 = rf(_a0, _a1...)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetNodeID provides a mock function with given fields: _a0, _a1
 func (_m *PChainClient) GetNodeID(_a0 context.Context, _a1 ...rpc.Option) (ids.NodeID, *signer.ProofOfPossession, error) {
 	_va := make([]interface{}, len(_a1))

--- a/mocks/client/p_chain_client.go
+++ b/mocks/client/p_chain_client.go
@@ -315,34 +315,6 @@ func (_m *PChainClient) GetNetworkID(_a0 context.Context, _a1 ...rpc.Option) (ui
 	return r0, r1
 }
 
-// GetNetworkName provides a mock function with given fields: _a0, _a1
-func (_m *PChainClient) GetNetworkName(_a0 context.Context, _a1 ...rpc.Option) (string, error) {
-	_va := make([]interface{}, len(_a1))
-	for _i := range _a1 {
-		_va[_i] = _a1[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, _a0)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func(context.Context, ...rpc.Option) string); ok {
-		r0 = rf(_a0, _a1...)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, ...rpc.Option) error); ok {
-		r1 = rf(_a0, _a1...)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetNodeID provides a mock function with given fields: _a0, _a1
 func (_m *PChainClient) GetNodeID(_a0 context.Context, _a1 ...rpc.Option) (ids.NodeID, *signer.ProofOfPossession, error) {
 	_va := make([]interface{}, len(_a1))

--- a/service/backend/cchainatomictx/account_test.go
+++ b/service/backend/cchainatomictx/account_test.go
@@ -38,7 +38,7 @@ var blockHeader = &ethtypes.Header{
 
 func TestAccountBalance(t *testing.T) {
 	evmMock := &mocks.Client{}
-	backend := NewBackend(evmMock, ids.Empty)
+	backend := NewBackend(evmMock, ids.Empty, avalancheNetworkID)
 	accountAddress := "C-fuji15f9g0h5xkr5cp47n6u3qxj6yjtzzzrdr23a3tl"
 
 	t.Run("C-chain atomic tx balance is sum of UTXOs", func(t *testing.T) {
@@ -74,7 +74,7 @@ func TestAccountBalance(t *testing.T) {
 
 func TestAccountCoins(t *testing.T) {
 	evmMock := &mocks.Client{}
-	backend := NewBackend(evmMock, ids.Empty)
+	backend := NewBackend(evmMock, ids.Empty, avalancheNetworkID)
 	// changing page size to 2 to test pagination as well
 	backend.getUTXOsPageSize = 2
 	accountAddress := "C-fuji15f9g0h5xkr5cp47n6u3qxj6yjtzzzrdr23a3tl"

--- a/service/backend/cchainatomictx/backend.go
+++ b/service/backend/cchainatomictx/backend.go
@@ -19,23 +19,25 @@ var (
 )
 
 type Backend struct {
-	fac              *crypto.FactorySECP256K1R
-	cClient          client.Client
-	getUTXOsPageSize uint32
-	codec            codec.Manager
-	codecVersion     uint16
-	avaxAssetID      ids.ID
+	fac                *crypto.FactorySECP256K1R
+	avalancheNetworkID uint32
+	cClient            client.Client
+	getUTXOsPageSize   uint32
+	codec              codec.Manager
+	codecVersion       uint16
+	avaxAssetID        ids.ID
 }
 
 // NewBackend creates a C-chain atomic transaction service backend
-func NewBackend(cClient client.Client, avaxAssetID ids.ID) *Backend {
+func NewBackend(cClient client.Client, avaxAssetID ids.ID, avalancheNetworkID uint32) *Backend {
 	return &Backend{
-		fac:              &crypto.FactorySECP256K1R{},
-		cClient:          cClient,
-		getUTXOsPageSize: 1024,
-		codec:            evm.Codec,
-		codecVersion:     0,
-		avaxAssetID:      avaxAssetID,
+		fac:                &crypto.FactorySECP256K1R{},
+		avalancheNetworkID: avalancheNetworkID,
+		cClient:            cClient,
+		getUTXOsPageSize:   1024,
+		codec:              evm.Codec,
+		codecVersion:       0,
+		avaxAssetID:        avaxAssetID,
 	}
 }
 

--- a/service/backend/cchainatomictx/construction.go
+++ b/service/backend/cchainatomictx/construction.go
@@ -132,18 +132,13 @@ func (b *Backend) ConstructionMetadata(
 		return nil, service.WrapError(service.ErrInvalidInput, err)
 	}
 
-	networkID, err := b.cClient.GetNetworkID(ctx)
-	if err != nil {
-		return nil, service.WrapError(service.ErrClientError, err)
-	}
-
 	cChainID, err := b.cClient.GetBlockchainID(ctx, constants.CChain.String())
 	if err != nil {
 		return nil, service.WrapError(service.ErrClientError, err)
 	}
 
 	metadata := cmapper.Metadata{
-		NetworkID: networkID,
+		NetworkID: b.avalancheNetworkID,
 		CChainID:  cChainID,
 	}
 

--- a/service/backend/cchainatomictx/construction_test.go
+++ b/service/backend/cchainatomictx/construction_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ava-labs/avalanchego/ids"
+	avaConst "github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -34,7 +35,7 @@ var (
 	cChainID, _ = ids.FromString("yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp")
 	pChainID    = ids.Empty
 
-	networkID = 5
+	avalancheNetworkID = avaConst.FujiID
 
 	avaxAssetID, _ = ids.FromString("U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK")
 )
@@ -52,7 +53,7 @@ func buildRosettaSignerJSON(coinIdentifiers []string, signers []*types.AccountId
 }
 
 func TestConstructionDerive(t *testing.T) {
-	backend := NewBackend(nil, ids.Empty)
+	backend := NewBackend(nil, ids.Empty, avalancheNetworkID)
 
 	t.Run("c-chain address", func(t *testing.T) {
 		src := "02e0d4392cfa224d4be19db416b3cf62e90fb2b7015e7b62a95c8cb490514943f6"
@@ -110,7 +111,7 @@ func TestExportTxConstruction(t *testing.T) {
 	suggestedFeeValue := "280750"
 
 	payloadsMetadata := map[string]interface{}{
-		"network_id":           float64(networkID),
+		"network_id":           float64(avalancheNetworkID),
 		"c_chain_id":           cChainID.String(),
 		"destination_chain":    constants.PChain.String(),
 		"destination_chain_id": pChainID.String(),
@@ -154,7 +155,7 @@ func TestExportTxConstruction(t *testing.T) {
 
 	ctx := context.Background()
 	clientMock := &mocks.Client{}
-	backend := NewBackend(clientMock, avaxAssetID)
+	backend := NewBackend(clientMock, avaxAssetID, avalancheNetworkID)
 
 	t.Run("preprocess endpoint", func(t *testing.T) {
 		req := &types.ConstructionPreprocessRequest{
@@ -176,7 +177,6 @@ func TestExportTxConstruction(t *testing.T) {
 			Options:           metadataOptions,
 		}
 
-		clientMock.On("GetNetworkID", ctx).Return(uint32(networkID), nil)
 		clientMock.On("GetBlockchainID", ctx, constants.CChain.String()).Return(cChainID, nil)
 		clientMock.On("GetBlockchainID", ctx, constants.PChain.String()).Return(pChainID, nil)
 		clientMock.
@@ -337,7 +337,7 @@ func TestImportTxConstruction(t *testing.T) {
 
 	payloadsMetadata := map[string]interface{}{
 		"nonce":           0.,
-		"network_id":      float64(networkID),
+		"network_id":      float64(avalancheNetworkID),
 		"c_chain_id":      cChainID.String(),
 		"source_chain_id": pChainID.String(),
 	}
@@ -385,7 +385,7 @@ func TestImportTxConstruction(t *testing.T) {
 
 	ctx := context.Background()
 	clientMock := &mocks.Client{}
-	backend := NewBackend(clientMock, avaxAssetID)
+	backend := NewBackend(clientMock, avaxAssetID, avalancheNetworkID)
 
 	t.Run("preprocess endpoint", func(t *testing.T) {
 		req := &types.ConstructionPreprocessRequest{
@@ -408,7 +408,6 @@ func TestImportTxConstruction(t *testing.T) {
 			Options:           metadataOptions,
 		}
 
-		clientMock.On("GetNetworkID", ctx).Return(uint32(networkID), nil)
 		clientMock.On("GetBlockchainID", ctx, constants.CChain.String()).Return(cChainID, nil)
 		clientMock.On("GetBlockchainID", ctx, constants.PChain.String()).Return(pChainID, nil)
 		clientMock.On("EstimateBaseFee", ctx).Return(big.NewInt(25_000_000_000), nil)

--- a/service/backend/pchain/account_test.go
+++ b/service/backend/pchain/account_test.go
@@ -46,7 +46,14 @@ func TestAccountBalance(t *testing.T) {
 	parserMock := &idxmocks.Parser{}
 	parserMock.Mock.On("GetGenesisBlock", ctx).Return(dummyGenesis, nil)
 	parserMock.Mock.On("ParseNonGenesisBlock", ctx, "", blockHeight).Return(parsedBlock, nil)
-	backend, err := NewBackend(service.ModeOnline, pChainMock, parserMock, avaxAssetID, pChainNetworkIdentifier)
+	backend, err := NewBackend(
+		service.ModeOnline,
+		pChainMock,
+		parserMock,
+		avaxAssetID,
+		pChainNetworkIdentifier,
+		avalancheNetworkID,
+	)
 	assert.Nil(t, err)
 	backend.getUTXOsPageSize = 2
 
@@ -205,7 +212,14 @@ func TestAccountCoins(t *testing.T) {
 	parserMock := &idxmocks.Parser{}
 	parserMock.Mock.On("GetGenesisBlock", ctx).Return(dummyGenesis, nil)
 	parserMock.Mock.On("ParseNonGenesisBlock", ctx, "", blockHeight).Return(parsedBlock, nil)
-	backend, err := NewBackend(service.ModeOnline, pChainMock, parserMock, avaxAssetID, pChainNetworkIdentifier)
+	backend, err := NewBackend(
+		service.ModeOnline,
+		pChainMock,
+		parserMock,
+		avaxAssetID,
+		pChainNetworkIdentifier,
+		avalancheNetworkID,
+	)
 	assert.Nil(t, err)
 
 	t.Run("Account Coins Test regular coins", func(t *testing.T) {

--- a/service/backend/pchain/backend.go
+++ b/service/backend/pchain/backend.go
@@ -25,16 +25,17 @@ var (
 
 type Backend struct {
 	genesisHandler
-	fac              *crypto.FactorySECP256K1R
-	networkID        *types.NetworkIdentifier
-	networkHRP       string
-	pClient          client.PChainClient
-	indexerParser    indexer.Parser
-	getUTXOsPageSize uint32
-	codec            codec.Manager
-	codecVersion     uint16
-	avaxAssetID      ids.ID
-	txParserCfg      pmapper.TxParserConfig
+	fac                *crypto.FactorySECP256K1R
+	networkID          *types.NetworkIdentifier
+	networkHRP         string
+	avalancheNetworkID uint32
+	pClient            client.PChainClient
+	indexerParser      indexer.Parser
+	getUTXOsPageSize   uint32
+	codec              codec.Manager
+	codecVersion       uint16
+	avaxAssetID        ids.ID
+	txParserCfg        pmapper.TxParserConfig
 }
 
 // NewBackend creates a P-chain service backend
@@ -44,19 +45,21 @@ func NewBackend(
 	indexerParser indexer.Parser,
 	assetID ids.ID,
 	networkIdentifier *types.NetworkIdentifier,
+	avalancheNetworkID uint32,
 ) (*Backend, error) {
 	genHandler := newGenesisHandler(nodeMode, indexerParser)
 
 	b := &Backend{
-		genesisHandler:   genHandler,
-		fac:              &crypto.FactorySECP256K1R{},
-		networkID:        networkIdentifier,
-		pClient:          pClient,
-		getUTXOsPageSize: 1024,
-		codec:            blocks.Codec,
-		codecVersion:     blocks.Version,
-		indexerParser:    indexerParser,
-		avaxAssetID:      assetID,
+		genesisHandler:     genHandler,
+		fac:                &crypto.FactorySECP256K1R{},
+		networkID:          networkIdentifier,
+		pClient:            pClient,
+		getUTXOsPageSize:   1024,
+		codec:              blocks.Codec,
+		codecVersion:       blocks.Version,
+		indexerParser:      indexerParser,
+		avaxAssetID:        assetID,
+		avalancheNetworkID: avalancheNetworkID,
 	}
 
 	if nodeMode == service.ModeOnline {

--- a/service/backend/pchain/backend.go
+++ b/service/backend/pchain/backend.go
@@ -47,7 +47,10 @@ func NewBackend(
 	networkIdentifier *types.NetworkIdentifier,
 	avalancheNetworkID uint32,
 ) (*Backend, error) {
-	genHandler := newGenesisHandler(nodeMode, indexerParser)
+	genHandler, err := newGenesisHandler(nodeMode, indexerParser)
+	if err != nil {
+		return nil, err
+	}
 
 	b := &Backend{
 		genesisHandler:     genHandler,

--- a/service/backend/pchain/backend.go
+++ b/service/backend/pchain/backend.go
@@ -47,7 +47,7 @@ func NewBackend(
 	networkIdentifier *types.NetworkIdentifier,
 	avalancheNetworkID uint32,
 ) (*Backend, error) {
-	genHandler, err := newGenesisHandler(nodeMode, indexerParser)
+	genHandler, err := newGenesisHandler(indexerParser)
 	if err != nil {
 		return nil, err
 	}

--- a/service/backend/pchain/backend_test.go
+++ b/service/backend/pchain/backend_test.go
@@ -35,7 +35,14 @@ func TestShouldHandleRequest(t *testing.T) {
 	clientMock.Mock.On("GetBlockchainID", ctx, constants.XChain.String()).Return(ids.ID{'X'}, nil)
 	parserMock := &idxmocks.Parser{}
 	parserMock.Mock.On("GetGenesisBlock", ctx).Return(dummyGenesis, nil)
-	backend, err := NewBackend(service.ModeOnline, clientMock, parserMock, avaxAssetID, pChainNetworkIdentifier)
+	backend, err := NewBackend(
+		service.ModeOnline,
+		clientMock,
+		parserMock,
+		avaxAssetID,
+		pChainNetworkIdentifier,
+		avalancheNetworkID,
+	)
 	assert.Nil(t, err)
 
 	testData := []struct {

--- a/service/backend/pchain/construction.go
+++ b/service/backend/pchain/construction.go
@@ -82,16 +82,12 @@ func (b *Backend) ConstructionMetadata(
 		return nil, service.WrapError(service.ErrInternalError, err)
 	}
 
-	networkID, err := b.pClient.GetNetworkID(ctx)
-	if err != nil {
-		return nil, service.WrapError(service.ErrInvalidInput, err)
-	}
-	metadata.NetworkID = networkID
-
 	pChainID, err := b.pClient.GetBlockchainID(ctx, constants.PChain.String())
 	if err != nil {
 		return nil, service.WrapError(service.ErrInvalidInput, err)
 	}
+
+	metadata.NetworkID = b.avalancheNetworkID
 	metadata.BlockchainID = pChainID
 
 	metadataMap, err := mapper.MarshalJSONMap(metadata)

--- a/service/backend/pchain/construction_test.go
+++ b/service/backend/pchain/construction_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/ids"
+	avaConst "github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	ajson "github.com/ava-labs/avalanchego/utils/json"
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -41,7 +42,7 @@ var (
 
 	nodeID = "NodeID-Bvsx89JttQqhqdgwtizAPoVSNW74Xcr2S"
 
-	networkID = 5
+	avalancheNetworkID = avaConst.FujiID
 
 	avaxAssetID, _ = ids.FromString("U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK")
 
@@ -73,10 +74,16 @@ func TestConstructionDerive(t *testing.T) {
 	pChainMock := &mocks.PChainClient{}
 	pChainMock.Mock.On("GetBlockchainID", ctx, constants.CChain.String()).Return(cChainID, nil)
 	pChainMock.Mock.On("GetBlockchainID", ctx, constants.XChain.String()).Return(ids.ID{'X'}, nil)
-	pChainMock.Mock.On("GetNetworkID", ctx).Return(uint32(5), nil)
 	parserMock := &idxmocks.Parser{}
 	parserMock.Mock.On("GetGenesisBlock", ctx).Return(dummyGenesis, nil)
-	backend, err := NewBackend(service.ModeOnline, pChainMock, parserMock, avaxAssetID, pChainNetworkIdentifier)
+	backend, err := NewBackend(
+		service.ModeOnline,
+		pChainMock,
+		parserMock,
+		avaxAssetID,
+		pChainNetworkIdentifier,
+		avalancheNetworkID,
+	)
 	assert.Nil(t, err)
 
 	t.Run("p-chain address", func(t *testing.T) {
@@ -145,7 +152,7 @@ func TestExportTxConstruction(t *testing.T) {
 	}
 
 	payloadsMetadata := map[string]interface{}{
-		"network_id":           float64(networkID),
+		"network_id":           float64(avalancheNetworkID),
 		"destination_chain":    constants.CChain.String(),
 		"destination_chain_id": cChainID.String(),
 		"blockchain_id":        pChainID.String(),
@@ -187,7 +194,14 @@ func TestExportTxConstruction(t *testing.T) {
 	clientMock := &mocks.PChainClient{}
 	parserMock := &idxmocks.Parser{}
 	parserMock.Mock.On("GetGenesisBlock", ctx).Return(dummyGenesis, nil)
-	backend, err := NewBackend(service.ModeOnline, clientMock, parserMock, avaxAssetID, pChainNetworkIdentifier)
+	backend, err := NewBackend(
+		service.ModeOnline,
+		clientMock,
+		parserMock,
+		avaxAssetID,
+		pChainNetworkIdentifier,
+		uint32(avalancheNetworkID),
+	)
 	assert.Nil(t, err)
 
 	t.Run("preprocess endpoint", func(t *testing.T) {
@@ -206,7 +220,6 @@ func TestExportTxConstruction(t *testing.T) {
 	})
 
 	t.Run("metadata endpoint", func(t *testing.T) {
-		clientMock.On("GetNetworkID", ctx).Return(uint32(networkID), nil)
 		clientMock.On("GetTxFee", ctx).Return(&info.GetTxFeeResponse{TxFee: ajson.Uint64(txFee)}, nil)
 		clientMock.On("GetBlockchainID", ctx, constants.PChain.String()).Return(pChainID, nil)
 		clientMock.On("GetBlockchainID", ctx, constants.CChain.String()).Return(cChainID, nil)
@@ -361,7 +374,7 @@ func TestImportTxConstruction(t *testing.T) {
 	}
 
 	payloadsMetadata := map[string]interface{}{
-		"network_id":      float64(networkID),
+		"network_id":      float64(avalancheNetworkID),
 		"source_chain_id": cChainID.String(),
 		"blockchain_id":   pChainID.String(),
 	}
@@ -401,7 +414,14 @@ func TestImportTxConstruction(t *testing.T) {
 	clientMock := &mocks.PChainClient{}
 	parserMock := &idxmocks.Parser{}
 	parserMock.Mock.On("GetGenesisBlock", ctx).Return(dummyGenesis, nil)
-	backend, err := NewBackend(service.ModeOnline, clientMock, parserMock, avaxAssetID, pChainNetworkIdentifier)
+	backend, err := NewBackend(
+		service.ModeOnline,
+		clientMock,
+		parserMock,
+		avaxAssetID,
+		pChainNetworkIdentifier,
+		uint32(avalancheNetworkID),
+	)
 	assert.Nil(t, err)
 
 	t.Run("preprocess endpoint", func(t *testing.T) {
@@ -420,7 +440,6 @@ func TestImportTxConstruction(t *testing.T) {
 	})
 
 	t.Run("metadata endpoint", func(t *testing.T) {
-		clientMock.On("GetNetworkID", ctx).Return(uint32(networkID), nil)
 		clientMock.On("GetTxFee", ctx).Return(&info.GetTxFeeResponse{TxFee: ajson.Uint64(txFee)}, nil)
 		clientMock.On("GetBlockchainID", ctx, constants.PChain.String()).Return(pChainID, nil)
 		clientMock.On("GetBlockchainID", ctx, constants.CChain.String()).Return(cChainID, nil)
@@ -591,7 +610,7 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 	}
 
 	payloadsMetadata := map[string]interface{}{
-		"network_id":       float64(networkID),
+		"network_id":       float64(avalancheNetworkID),
 		"blockchain_id":    pChainID.String(),
 		"node_id":          nodeID,
 		"start":            float64(startTime),
@@ -638,7 +657,14 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 	clientMock := &mocks.PChainClient{}
 	parserMock := &idxmocks.Parser{}
 	parserMock.Mock.On("GetGenesisBlock", ctx).Return(dummyGenesis, nil)
-	backend, err := NewBackend(service.ModeOnline, clientMock, parserMock, avaxAssetID, pChainNetworkIdentifier)
+	backend, err := NewBackend(
+		service.ModeOnline,
+		clientMock,
+		parserMock,
+		avaxAssetID,
+		pChainNetworkIdentifier,
+		uint32(avalancheNetworkID),
+	)
 	assert.Nil(t, err)
 
 	t.Run("preprocess endpoint", func(t *testing.T) {
@@ -657,7 +683,6 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 	})
 
 	t.Run("metadata endpoint", func(t *testing.T) {
-		clientMock.On("GetNetworkID", ctx).Return(uint32(networkID), nil)
 		clientMock.On("GetBlockchainID", ctx, constants.PChain.String()).Return(pChainID, nil)
 
 		resp, err := backend.ConstructionMetadata(
@@ -823,7 +848,7 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 	}
 
 	payloadsMetadata := map[string]interface{}{
-		"network_id":       float64(networkID),
+		"network_id":       float64(avalancheNetworkID),
 		"blockchain_id":    pChainID.String(),
 		"node_id":          nodeID,
 		"start":            float64(startTime),
@@ -870,7 +895,14 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 	clientMock := &mocks.PChainClient{}
 	parserMock := &idxmocks.Parser{}
 	parserMock.Mock.On("GetGenesisBlock", ctx).Return(dummyGenesis, nil)
-	backend, err := NewBackend(service.ModeOnline, clientMock, parserMock, avaxAssetID, pChainNetworkIdentifier)
+	backend, err := NewBackend(
+		service.ModeOnline,
+		clientMock,
+		parserMock,
+		avaxAssetID,
+		pChainNetworkIdentifier,
+		uint32(avalancheNetworkID),
+	)
 	assert.Nil(t, err)
 
 	t.Run("preprocess endpoint", func(t *testing.T) {
@@ -889,7 +921,6 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 	})
 
 	t.Run("metadata endpoint", func(t *testing.T) {
-		clientMock.On("GetNetworkID", ctx).Return(uint32(networkID), nil)
 		clientMock.On("GetBlockchainID", ctx, constants.PChain.String()).Return(pChainID, nil)
 
 		resp, err := backend.ConstructionMetadata(

--- a/service/backend/pchain/construction_test.go
+++ b/service/backend/pchain/construction_test.go
@@ -200,7 +200,7 @@ func TestExportTxConstruction(t *testing.T) {
 		parserMock,
 		avaxAssetID,
 		pChainNetworkIdentifier,
-		uint32(avalancheNetworkID),
+		avalancheNetworkID,
 	)
 	assert.Nil(t, err)
 
@@ -420,7 +420,7 @@ func TestImportTxConstruction(t *testing.T) {
 		parserMock,
 		avaxAssetID,
 		pChainNetworkIdentifier,
-		uint32(avalancheNetworkID),
+		avalancheNetworkID,
 	)
 	assert.Nil(t, err)
 
@@ -663,7 +663,7 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 		parserMock,
 		avaxAssetID,
 		pChainNetworkIdentifier,
-		uint32(avalancheNetworkID),
+		avalancheNetworkID,
 	)
 	assert.Nil(t, err)
 
@@ -901,7 +901,7 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 		parserMock,
 		avaxAssetID,
 		pChainNetworkIdentifier,
-		uint32(avalancheNetworkID),
+		avalancheNetworkID,
 	)
 	assert.Nil(t, err)
 

--- a/service/backend/pchain/genesis_handler.go
+++ b/service/backend/pchain/genesis_handler.go
@@ -26,7 +26,7 @@ type genesisHandler interface {
 	buildGenesisAllocationTx() (*txs.Tx, error)
 }
 
-func newGenesisHandler(nodeMode string, indexerParser indexer.Parser) (genesisHandler, error) {
+func newGenesisHandler(indexerParser indexer.Parser) (genesisHandler, error) {
 	gh := &gHandler{
 		indexerParser: indexerParser,
 

--- a/service/backend/pchain/genesis_handler.go
+++ b/service/backend/pchain/genesis_handler.go
@@ -2,7 +2,6 @@ package pchain
 
 import (
 	"context"
-	"errors"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
@@ -12,7 +11,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/coinbase/rosetta-sdk-go/types"
 
-	"github.com/ava-labs/avalanche-rosetta/service"
 	"github.com/ava-labs/avalanche-rosetta/service/backend/pchain/indexer"
 )
 
@@ -28,7 +26,7 @@ type genesisHandler interface {
 	buildGenesisAllocationTx() (*txs.Tx, error)
 }
 
-func newGenesisHandler(nodeMode string, indexerParser indexer.Parser) genesisHandler {
+func newGenesisHandler(nodeMode string, indexerParser indexer.Parser) (genesisHandler, error) {
 	gh := &gHandler{
 		indexerParser: indexerParser,
 
@@ -38,51 +36,34 @@ func newGenesisHandler(nodeMode string, indexerParser indexer.Parser) genesisHan
 		genesisCodec: blocks.GenesisCodec,
 	}
 
-	// Initializing genesis block from indexer only in online mode
-	if nodeMode == service.ModeOnline {
-		_ = gh.lazyLoadGenesisBlk()
-	}
-
-	return gh
+	// initializing genesis block. No network calls are involved.
+	return gh, gh.loadGenesisBlk()
 }
 
 type gHandler struct {
 	indexerParser indexer.Parser
 	genesisCodec  codec.Manager
 
-	// genesisBlk is lazily initialized, as soon as
-	// pChainClient is ready to serve requests
-	genesisBlkFetched bool
 	genesisBlk        *indexer.ParsedGenesisBlock
 	genesisIdentifier *types.BlockIdentifier
 
 	allocationTx *txs.Tx
 }
 
-func (gh *gHandler) lazyLoadGenesisBlk() bool {
-	if gh.genesisBlkFetched {
-		return true // genesis block loaded
-	}
-
+func (gh *gHandler) loadGenesisBlk() error {
 	genesisBlk, err := gh.indexerParser.GetGenesisBlock(context.Background())
-	if err == nil {
-		gh.genesisBlkFetched = true
-		gh.genesisBlk = genesisBlk
-		gh.genesisIdentifier = &types.BlockIdentifier{
-			Index: int64(genesisBlk.Height),
-			Hash:  genesisBlk.BlockID.String(),
-		}
-		return true // genesis block loaded
+	if err != nil {
+		return err
 	}
-
-	return false // genesis block not loaded
+	gh.genesisBlk = genesisBlk
+	gh.genesisIdentifier = &types.BlockIdentifier{
+		Index: int64(genesisBlk.Height),
+		Hash:  genesisBlk.BlockID.String(),
+	}
+	return nil
 }
 
 func (gh *gHandler) isGenesisBlockRequest(index int64, hash string) (bool, error) {
-	if loaded := gh.lazyLoadGenesisBlk(); !loaded {
-		return false, errors.New("could not load genesis data")
-	}
-
 	// if hash is provided, make sure it matches genesis block hash
 	if hash != "" {
 		return hash == gh.genesisBlk.BlockID.String(), nil
@@ -92,20 +73,14 @@ func (gh *gHandler) isGenesisBlockRequest(index int64, hash string) (bool, error
 	return index == int64(gh.genesisBlk.Height), nil
 }
 
-// getGenesisBlock is a simple getter for genesisBlk. It does not check
-// whether genesisBlk has been duly initialized. Check is up to caller
 func (gh *gHandler) getGenesisBlock() *indexer.ParsedGenesisBlock {
 	return gh.genesisBlk
 }
 
-// getGenesisIdentifier is a simple getter for genesisIdentifier. It does not check
-// whether genesisIdentifier has been duly initialized. Check is up to caller
 func (gh *gHandler) getGenesisIdentifier() *types.BlockIdentifier {
 	return gh.genesisIdentifier
 }
 
-// getFullGenesisTxs does not check whether genesis
-// has been duly initialized. Check is up to caller
 func (gh *gHandler) getFullGenesisTxs() ([]*txs.Tx, error) {
 	res := gh.genesisBlk.Txs
 	allocationTx, err := gh.buildGenesisAllocationTx()

--- a/service/backend/pchain/indexer/parser_test.go
+++ b/service/backend/pchain/indexer/parser_test.go
@@ -64,9 +64,7 @@ func readFixture(path string, sprintfArgs ...interface{}) []byte {
 
 func TestMain(m *testing.M) {
 	ctx := context.Background()
-
 	pchainClient := &mocks.PChainClient{}
-	pchainClient.On("GetNetworkID", mock.Anything).Return(constants.MainnetID, nil).Once()
 
 	for _, idx := range idxs {
 		ret := readFixture("ins/%v.json", idx)
@@ -93,7 +91,7 @@ func TestMain(m *testing.M) {
 
 	pchainClient.On("GetHeight", ctx, mock.Anything).Return(uint64(1000000), nil)
 
-	p, err = NewParser(pchainClient)
+	p, err = NewParser(pchainClient, constants.MainnetID)
 	if err != nil {
 		panic(err)
 	}
@@ -128,11 +126,9 @@ func TestGenesisBlockCreateChainTxs(t *testing.T) {
 
 func TestGenesisBlockParseTxs(t *testing.T) {
 	a := assert.New(t)
-
 	pchainClient := &mocks.PChainClient{}
-	pchainClient.On("GetNetworkID", mock.Anything).Return(constants.FujiID, nil).Once()
 
-	p, err := NewParser(pchainClient)
+	p, err := NewParser(pchainClient, constants.FujiID)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Calling GetNetworkID is not really necessary. All networks known to avalanchego are in its constants package.
So by using that constant package we can simplfy avalanche rosetta logic and we don't need to lazily initialize genesis.