### PR TITLE
disable state-sync by default

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,6 +23,7 @@ mkdir -p /app/configs/chains/C
 
 cat <<EOF > /app/configs/chains/C/config.json
 {
+  "state-sync-enables": false,
   "snowman-api-enabled": false,
   "coreth-admin-api-enabled": false,
   "rpc-gas-cap": 2500000000,

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,7 +23,7 @@ mkdir -p /app/configs/chains/C
 
 cat <<EOF > /app/configs/chains/C/config.json
 {
-  "state-sync-enables": false,
+  "state-sync-enabled": false,
   "snowman-api-enabled": false,
   "coreth-admin-api-enabled": false,
   "rpc-gas-cap": 2500000000,


### PR DESCRIPTION
Disable state sync by default on rosetta.