### PR TITLE
fix genesis allocation UTXO lookup logic during block parsing

### DIFF
--- a/mapper/pchain/tx_dependency.go
+++ b/mapper/pchain/tx_dependency.go
@@ -3,13 +3,14 @@ package pchain
 import (
 	"fmt"
 
-	"github.com/ava-labs/avalanche-rosetta/constants"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/coinbase/rosetta-sdk-go/types"
+
+	"github.com/ava-labs/avalanche-rosetta/constants"
 )
 
 type BlockTxDependencies map[ids.ID]*SingleTxDependency

--- a/service/backend/pchain/block_test.go
+++ b/service/backend/pchain/block_test.go
@@ -1,0 +1,144 @@
+package pchain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/api"
+	"github.com/ava-labs/avalanchego/ids"
+	avaConst "github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/formatting"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	avaTypes "github.com/ava-labs/avalanchego/vms/types"
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanche-rosetta/constants"
+	mocks "github.com/ava-labs/avalanche-rosetta/mocks/client"
+	indexerMocks "github.com/ava-labs/avalanche-rosetta/mocks/service/backend/pchain/indexer"
+	"github.com/ava-labs/avalanche-rosetta/service"
+	"github.com/ava-labs/avalanche-rosetta/service/backend/pchain/indexer"
+)
+
+func TestFetchBlkDependencies(t *testing.T) {
+	dummyGenesis = &indexer.ParsedGenesisBlock{}
+
+	mockPClient := mocks.NewPChainClient(t)
+	mockIndexerParser := indexerMocks.NewParser(t)
+
+	ctx := context.Background()
+
+	networkID := avaConst.MainnetID
+	networkIdentifier := &types.NetworkIdentifier{
+		Blockchain: service.BlockchainName,
+		Network:    constants.MainnetNetwork,
+		SubNetworkIdentifier: &types.SubNetworkIdentifier{
+			Network: constants.PChain.String(),
+		},
+	}
+
+	signedImportTx, err := makeImportTx(t, networkID)
+	require.Nil(t, err)
+
+	genesisTxID := ids.Empty
+	nonGenesisTxID := signedImportTx.ID()
+
+	tx := &txs.Tx{
+		Unsigned: &txs.ExportTx{
+			BaseTx: txs.BaseTx{
+				BaseTx: avax.BaseTx{
+					NetworkID:    avalancheNetworkID,
+					BlockchainID: pChainID,
+					Ins: []*avax.TransferableInput{
+						{
+							UTXOID: avax.UTXOID{
+								// Genesis allocation input
+								TxID:        genesisTxID,
+								OutputIndex: 1234,
+							},
+							Asset: avax.Asset{
+								ID: avaxAssetID,
+							},
+							In: &secp256k1fx.TransferInput{
+								Amt:   1000,
+								Input: secp256k1fx.Input{},
+							},
+						},
+						{
+							UTXOID: avax.UTXOID{
+								TxID:        nonGenesisTxID,
+								OutputIndex: 1,
+							},
+							Asset: avax.Asset{
+								ID: avaxAssetID,
+							},
+							In: &secp256k1fx.TransferInput{
+								Amt:   2000,
+								Input: secp256k1fx.Input{},
+							},
+						},
+					},
+				},
+			},
+			DestinationChain: cChainID,
+			ExportedOutputs:  nil,
+		},
+	}
+
+	mockIndexerParser.Mock.On("GetGenesisBlock", ctx).Return(dummyGenesis, nil)
+	mockPClient.Mock.On("GetTx", mock.Anything, nonGenesisTxID).Return(signedImportTx.Bytes(), nil)
+
+	mockPClient.Mock.On("GetRewardUTXOs", mock.Anything, &api.GetTxArgs{
+		TxID:     nonGenesisTxID,
+		Encoding: formatting.Hex,
+	}).Return(nil, nil)
+
+	backend, err := NewBackend(service.ModeOnline, mockPClient, mockIndexerParser, avaxAssetID, networkIdentifier, networkID)
+	require.Nil(t, err)
+
+	deps, err := backend.fetchBlkDependencies(ctx, []*txs.Tx{tx})
+	require.Nil(t, err)
+
+	mockPClient.AssertExpectations(t)
+	mockIndexerParser.AssertExpectations(t)
+
+	require.Equal(t, 2, len(deps))
+	require.Equal(t, ids.Empty, deps[genesisTxID].Tx.ID())
+	require.NotEqual(t, ids.Empty, deps[nonGenesisTxID].Tx.ID())
+	require.Equal(t, signedImportTx, deps[nonGenesisTxID].Tx)
+}
+
+func makeImportTx(t *testing.T, networkID uint32) (*txs.Tx, error) {
+	importTx := &txs.ImportTx{
+		BaseTx: txs.BaseTx{
+			BaseTx: avax.BaseTx{
+				NetworkID: networkID,
+				Outs: []*avax.TransferableOutput{
+					{
+						Asset: avax.Asset{
+							ID: avaxAssetID,
+						},
+						Out: &secp256k1fx.TransferOutput{
+							Amt:          2000,
+							OutputOwners: secp256k1fx.OutputOwners{Addrs: []ids.ShortID{}},
+						},
+					},
+				},
+				Ins:  []*avax.TransferableInput{},
+				Memo: avaTypes.JSONByteSlice{},
+			},
+			SyntacticallyVerified: false,
+		},
+		SourceChain:    cChainID,
+		ImportedInputs: []*avax.TransferableInput{},
+	}
+	signedImportTx, err := txs.NewSigned(importTx, blocks.Codec, nil)
+	require.Nil(t, err)
+	signedImportTx.Creds = []verify.Verifiable{}
+	return signedImportTx, err
+}

--- a/service/backend/pchain/genesis_handler.go
+++ b/service/backend/pchain/genesis_handler.go
@@ -129,14 +129,13 @@ func (gh *gHandler) buildGenesisAllocationTx() (*txs.Tx, error) {
 
 	// TODO: this is probably not the right way to build this tx
 	// Some fields are missing that we populate in tx Builder
+	// We also do not sign/initialize the transaction since genesis outputs are referred to empty id as tx id.
 	allocationTx := &txs.ImportTx{}
 	allocationTx.Outs = outs
 	tx := &txs.Tx{
 		Unsigned: allocationTx,
 	}
-	if err := tx.Sign(gh.genesisCodec, nil); err != nil {
-		return nil, err
-	}
+
 	gh.allocationTx = tx
 	return gh.allocationTx, nil
 }


### PR DESCRIPTION
This PR fixes a regression introduced during recent refactors to P-chain logic related to dependency transaction lookup on block parsing where the genesis allocation utxos were indexed using an incorrect transaction id. 

#### Testing
- Ran Fuji data validation
- Queried /block endpoint with height 4771889 which consumes UTXOs from genesis allocation

```json
{
    "block": {
        "block_identifier": {
            "index": 4771889,
            "hash": "2oD1vjLUuH1TMi8MgAe9PmFE8bbybh6YthDjKKkbTSnyLsnzZV"
        },
        "parent_block_identifier": {
            "index": 4771888,
            "hash": "M8y1ZFeVXeLc9DkpyxF8m3E3KLdsW9qc5RHQeELgAWaSco11b"
        },
        "timestamp": 1679169579000,
        "transactions": [
            {
                "transaction_identifier": {
                    "hash": "24w1sg4fjTv1sDhjf1rDUQG7HcpFKEPyKhawJRDhzYraQFhpoP"
                },
                "operations": [
                    {
                        "operation_identifier": {
                            "index": 0
                        },
                        "type": "EXPORT_AVAX",
                        "status": "SUCCESS",
                        "account": {
                            "address": "P-avax162w98xqkcwnhtz3la2f9l3nn5rcu99q4pcee5q"
                        },
                        "amount": {
                            "value": "-11250000000",
                            "currency": {
                                "symbol": "AVAX",
                                "decimals": 9
                            }
                        },
                        "coin_change": {
                            "coin_identifier": {
                                "identifier": "11111111111111111111111111111111LpoYY:10536"
                            },
                            "coin_action": "coin_spent"
                        },
                        "metadata": {
                            "locktime": 0,
                            "sig_indices": [
                                0
                            ],
                            "type": "INPUT"
                        }
                    },
                    {
                        "operation_identifier": {
                            "index": 1
                        },
                        "type": "EXPORT_AVAX",
                        "status": "SUCCESS",
                        "account": {
                            "address": "P-avax162w98xqkcwnhtz3la2f9l3nn5rcu99q4pcee5q"
                        },
                        "amount": {
                            "value": "-11250000000",
                            "currency": {
                                "symbol": "AVAX",
                                "decimals": 9
                            }
                        },
                        "coin_change": {
                            "coin_identifier": {
                                "identifier": "11111111111111111111111111111111LpoYY:10537"
                            },
                            "coin_action": "coin_spent"
                        },
                        "metadata": {
                            "locktime": 0,
                            "sig_indices": [
                                0
                            ],
                            "type": "INPUT"
                        }
                    },
                    {
                        "operation_identifier": {
                            "index": 2
                        },
                        "type": "EXPORT_AVAX",
                        "status": "SUCCESS",
                        "account": {
                            "address": "P-avax162w98xqkcwnhtz3la2f9l3nn5rcu99q4pcee5q"
                        },
                        "amount": {
                            "value": "-11250000000",
                            "currency": {
                                "symbol": "AVAX",
                                "decimals": 9
                            }
                        },
                        "coin_change": {
                            "coin_identifier": {
                                "identifier": "11111111111111111111111111111111LpoYY:10538"
                            },
                            "coin_action": "coin_spent"
                        },
                        "metadata": {
                            "locktime": 0,
                            "sig_indices": [
                                0
                            ],
                            "type": "INPUT"
                        }
                    },
                    {
                        "operation_identifier": {
                            "index": 3
                        },
                        "type": "EXPORT_AVAX",
                        "status": "SUCCESS",
                        "account": {
                            "address": "P-avax162w98xqkcwnhtz3la2f9l3nn5rcu99q4pcee5q"
                        },
                        "amount": {
                            "value": "-11250000000",
                            "currency": {
                                "symbol": "AVAX",
                                "decimals": 9
                            }
                        },
                        "coin_change": {
                            "coin_identifier": {
                                "identifier": "11111111111111111111111111111111LpoYY:10539"
                            },
                            "coin_action": "coin_spent"
                        },
                        "metadata": {
                            "locktime": 0,
                            "sig_indices": [
                                0
                            ],
                            "type": "INPUT"
                        }
                    }
                ],
                "metadata": {
                    "exported_outputs": [
                        {
                            "operation_identifier": {
                                "index": 4
                            },
                            "type": "EXPORT_AVAX",
                            "status": "SUCCESS",
                            "account": {
                                "address": "X-avax1rnxsthfzyu2v8smzrtdrg8xwkshk6m3ckrf3ke"
                            },
                            "amount": {
                                "value": "44999000000",
                                "currency": {
                                    "symbol": "AVAX",
                                    "decimals": 9
                                }
                            },
                            "coin_change": {
                                "coin_identifier": {
                                    "identifier": "24w1sg4fjTv1sDhjf1rDUQG7HcpFKEPyKhawJRDhzYraQFhpoP:0"
                                },
                                "coin_action": "coin_created"
                            },
                            "metadata": {
                                "locktime": 0,
                                "threshold": 1,
                                "type": "EXPORT"
                            }
                        }
                    ],
                    "tx_type": "EXPORT_AVAX"
                }
            }
        ]
    }
}
```