### PR TITLE
use validatorsOnly flag in GetStake

### DIFF
--- a/client/pchainclient.go
+++ b/client/pchainclient.go
@@ -59,7 +59,7 @@ type PChainClient interface {
 	GetTx(ctx context.Context, txID ids.ID, options ...rpc.Option) ([]byte, error)
 	GetBlock(ctx context.Context, blockID ids.ID, options ...rpc.Option) ([]byte, error)
 	IssueTx(ctx context.Context, tx []byte, options ...rpc.Option) (ids.ID, error)
-	GetStake(ctx context.Context, addrs []ids.ShortID, options ...rpc.Option) (map[ids.ID]uint64, [][]byte, error)
+	GetStake(ctx context.Context, addrs []ids.ShortID, validatorsOnly bool, options ...rpc.Option) (map[ids.ID]uint64, [][]byte, error)
 	GetCurrentValidators(ctx context.Context, subnetID ids.ID, nodeIDs []ids.NodeID, options ...rpc.Option) ([]platformvm.ClientPermissionlessValidator, error)
 
 	// avm.Client methods

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ava-labs/avalanche-rosetta
 go 1.19
 
 require (
-	github.com/ava-labs/avalanchego v1.10.0
+	github.com/ava-labs/avalanchego v1.10.1-rc.1
 	github.com/ava-labs/coreth v0.12.0-rc.2
 	github.com/coinbase/rosetta-sdk-go v0.6.5
 	github.com/ethereum/go-ethereum v1.10.26

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aristanetworks/goarista v0.0.0-20170210015632-ea17b1a17847/go.mod h1:D/tb0zPVXnP7fmsLZjtdUhSsumbK/ij54UXjjVgMGxQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.10.0 h1:Rn6Nyd62OkzQG5QpCgtCGVXtjuiaEzxV000kqG9aUIg=
-github.com/ava-labs/avalanchego v1.10.0/go.mod h1:hTaSLGN4y/EmhmYd+yjUj9Lsm00q70V78jOYDdnLrgQ=
+github.com/ava-labs/avalanchego v1.10.1-rc.1 h1:LZJ94sVyXXcW0UY+sti+aqXuHDSmoiKu8s6hwj5Muyk=
+github.com/ava-labs/avalanchego v1.10.1-rc.1/go.mod h1:hTaSLGN4y/EmhmYd+yjUj9Lsm00q70V78jOYDdnLrgQ=
 github.com/ava-labs/coreth v0.12.0-rc.2 h1:UNyGhuC2HxZ8eCLZiZON8xRiJkNHVZ75zknu/xqkKBA=
 github.com/ava-labs/coreth v0.12.0-rc.2/go.mod h1:ZGhoIZTWbIaTmzEbprXu0hLtLdoE2PSTEFnCTYr0BRk=
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=

--- a/mocks/client/p_chain_client.go
+++ b/mocks/client/p_chain_client.go
@@ -419,41 +419,41 @@ func (_m *PChainClient) GetRewardUTXOs(_a0 context.Context, _a1 *api.GetTxArgs, 
 	return r0, r1
 }
 
-// GetStake provides a mock function with given fields: ctx, addrs, options
-func (_m *PChainClient) GetStake(ctx context.Context, addrs []ids.ShortID, options ...rpc.Option) (map[ids.ID]uint64, [][]byte, error) {
+// GetStake provides a mock function with given fields: ctx, addrs, validatorsOnly, options
+func (_m *PChainClient) GetStake(ctx context.Context, addrs []ids.ShortID, validatorsOnly bool, options ...rpc.Option) (map[ids.ID]uint64, [][]byte, error) {
 	_va := make([]interface{}, len(options))
 	for _i := range options {
 		_va[_i] = options[_i]
 	}
 	var _ca []interface{}
-	_ca = append(_ca, ctx, addrs)
+	_ca = append(_ca, ctx, addrs, validatorsOnly)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
 	var r0 map[ids.ID]uint64
 	var r1 [][]byte
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, []ids.ShortID, ...rpc.Option) (map[ids.ID]uint64, [][]byte, error)); ok {
-		return rf(ctx, addrs, options...)
+	if rf, ok := ret.Get(0).(func(context.Context, []ids.ShortID, bool, ...rpc.Option) (map[ids.ID]uint64, [][]byte, error)); ok {
+		return rf(ctx, addrs, validatorsOnly, options...)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, []ids.ShortID, ...rpc.Option) map[ids.ID]uint64); ok {
-		r0 = rf(ctx, addrs, options...)
+	if rf, ok := ret.Get(0).(func(context.Context, []ids.ShortID, bool, ...rpc.Option) map[ids.ID]uint64); ok {
+		r0 = rf(ctx, addrs, validatorsOnly, options...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[ids.ID]uint64)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, []ids.ShortID, ...rpc.Option) [][]byte); ok {
-		r1 = rf(ctx, addrs, options...)
+	if rf, ok := ret.Get(1).(func(context.Context, []ids.ShortID, bool, ...rpc.Option) [][]byte); ok {
+		r1 = rf(ctx, addrs, validatorsOnly, options...)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).([][]byte)
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, []ids.ShortID, ...rpc.Option) error); ok {
-		r2 = rf(ctx, addrs, options...)
+	if rf, ok := ret.Get(2).(func(context.Context, []ids.ShortID, bool, ...rpc.Option) error); ok {
+		r2 = rf(ctx, addrs, validatorsOnly, options...)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/service/backend/pchain/account.go
+++ b/service/backend/pchain/account.go
@@ -416,8 +416,11 @@ func (b *Backend) fetchUTXOsAndStakedOutputs(ctx context.Context, addr ids.Short
 
 	var stakedUTXOBytes [][]byte
 	if fetchStaked {
-		// fetch staked outputs for addr
-		_, stakedUTXOBytes, err = b.pClient.GetStake(ctx, []ids.ShortID{addr})
+		// Fetch staked outputs for addr. We are setting validatorsOnly parameter to true in order to speed up the
+		// staked UTXO lookup.
+		// The tradeoff for using this parameter is that we only fetch UTXOs for validator staking and not for delegation.
+		// Effectively, we are assuming the balance lookups for staked amounts refer to validator staking only.
+		_, stakedUTXOBytes, err = b.pClient.GetStake(ctx, []ids.ShortID{addr}, true)
 		if err != nil {
 			return 0, nil, nil, service.WrapError(service.ErrInvalidInput, "unable to get stake")
 		}

--- a/service/backend/pchain/account_test.go
+++ b/service/backend/pchain/account_test.go
@@ -83,7 +83,7 @@ func TestAccountBalance(t *testing.T) {
 			Return([][]byte{utxo0Bytes, utxo1Bytes}, addr, utxo1Id, nil).Once()
 		pChainMock.Mock.On("GetAtomicUTXOs", ctx, []ids.ShortID{addr}, "", pageSize, addr, utxo1Id).
 			Return([][]byte{utxo1Bytes}, addr, utxo1Id, nil).Once()
-		pChainMock.Mock.On("GetStake", ctx, []ids.ShortID{addr}).Return(map[ids.ID]uint64{}, [][]byte{stakeUtxoBytes}, nil).Once()
+		pChainMock.Mock.On("GetStake", ctx, []ids.ShortID{addr}, true).Return(map[ids.ID]uint64{}, [][]byte{stakeUtxoBytes}, nil).Once()
 
 		resp, err := backend.AccountBalance(
 			ctx,
@@ -178,7 +178,7 @@ func TestAccountBalance(t *testing.T) {
 		pChainMock.Mock.On("GetHeight", ctx).Return(blockHeight, nil).Once()
 		pChainMock.Mock.On("GetAtomicUTXOs", ctx, []ids.ShortID{addr}, "", pageSize, ids.ShortEmpty, ids.Empty).
 			Return([][]byte{}, addr, ids.Empty, nil).Once()
-		pChainMock.Mock.On("GetStake", ctx, []ids.ShortID{addr}).Return(map[ids.ID]uint64{}, [][]byte{}, nil)
+		pChainMock.Mock.On("GetStake", ctx, []ids.ShortID{addr}, true).Return(map[ids.ID]uint64{}, [][]byte{}, nil)
 		// return blockHeight + 1 to indicate a new block arrival
 		pChainMock.Mock.On("GetHeight", ctx).Return(blockHeight+1, nil).Once()
 


### PR DESCRIPTION
In order to speed up GetStake calls avalanchego is introducing the `validatorsOnly` parameter. This change sets that parameter to true.