### PR TITLE
Enable arbitrary contract call support

### DIFF
--- a/service/contract_call_data.go
+++ b/service/contract_call_data.go
@@ -1,0 +1,181 @@
+package service
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log"
+	"math/big"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"golang.org/x/crypto/sha3"
+)
+
+// constructContractCallDataGeneric constructs the data field of a transaction.
+// The methodArgs can be already in ABI encoded format in case of a single string
+// It can also be passed in as a slice of args, which requires further encoding.
+func constructContractCallDataGeneric(methodSig string, methodArgs interface{}) ([]byte, error) {
+	data, err := contractCallMethodID(methodSig)
+	if err != nil {
+		return nil, err
+	}
+
+	// switch on the type of the method args. method args can come in from json as either a string or list of strings
+	switch methodArgs := methodArgs.(type) {
+	// case 0: no method arguments, return the selector
+	case nil:
+		return data, nil
+
+	// case 1: method args are pre-compiled ABI data. decode the hex and create the call data directly
+	case string:
+		methodArgs = strings.TrimPrefix(methodArgs, "0x")
+		b, decErr := hex.DecodeString(methodArgs)
+		if decErr != nil {
+			return nil, fmt.Errorf("error decoding method args hex data: %w", decErr)
+		}
+		return append(data, b...), nil
+
+	// case 2: method args are a list of interface{} which will be converted to string before encoding
+	case []interface{}:
+		var strList []string
+		for i, genericVal := range methodArgs {
+			strVal, isStrVal := genericVal.(string)
+			if !isStrVal {
+				return nil, fmt.Errorf("invalid method_args type at index %d: %T (must be a string)",
+					i, genericVal,
+				)
+			}
+			strList = append(strList, strVal)
+		}
+		return encodeMethodArgsStrings(data, methodSig, strList)
+
+	// case 3: method args are encoded as a list of strings, which will be decoded
+	case []string:
+		return encodeMethodArgsStrings(data, methodSig, methodArgs)
+
+	// case 4: there is no known way to decode the method args
+	default:
+		return nil, fmt.Errorf(
+			"invalid method_args type, accepted values are []string and hex-encoded string."+
+				" type received=%T value=%#v", methodArgs, methodArgs,
+		)
+	}
+}
+
+// encodeMethodArgsStrings constructs the data field of a transaction for a list of string args.
+// It attempts to first convert the string arg to it's corresponding type in the method signature,
+// and then performs abi encoding to the converted args list and construct the data.
+func encodeMethodArgsStrings(methodID []byte, methodSig string, methodArgs []string) ([]byte, error) {
+	arguments := abi.Arguments{}
+	var argumentsData []interface{}
+
+	var data []byte
+	data = append(data, methodID...)
+
+	const split = 2
+	splitSigByLeadingParenthesis := strings.Split(methodSig, "(")
+	if len(splitSigByLeadingParenthesis) < split {
+		return data, nil
+	}
+	splitSigByTrailingParenthesis := strings.Split(splitSigByLeadingParenthesis[1], ")")
+	if len(splitSigByTrailingParenthesis) < 1 {
+		return data, nil
+	}
+	splitSigByComma := strings.Split(splitSigByTrailingParenthesis[0], ",")
+
+	if len(splitSigByComma) != len(methodArgs) {
+		return nil, errors.New("invalid method arguments")
+	}
+
+	for i, v := range splitSigByComma {
+		typed, _ := abi.NewType(v, v, nil)
+		argument := abi.Arguments{
+			{
+				Type: typed,
+			},
+		}
+
+		arguments = append(arguments, argument...)
+		var argData interface{}
+		const base = 10
+		switch {
+		case v == "address":
+			{
+				argData = common.HexToAddress(methodArgs[i])
+			}
+		case v == "uint32":
+			{
+				u64, err := strconv.ParseUint(methodArgs[i], 10, 32)
+				if err != nil {
+					log.Fatal(err)
+				}
+				argData = uint32(u64)
+			}
+		case strings.HasPrefix(v, "uint") || strings.HasPrefix(v, "int"):
+			{
+				value := new(big.Int)
+				value.SetString(methodArgs[i], base)
+				argData = value
+			}
+		case v == "bytes32":
+			{
+				value := [32]byte{}
+				bytes, err := hexutil.Decode(methodArgs[i])
+				if err != nil {
+					log.Fatal(err)
+				}
+				copy(value[:], bytes)
+				argData = value
+			}
+		case strings.HasPrefix(v, "bytes"):
+			{
+				// No fixed size set as it would make it an "array" instead
+				// of a "slice" when encoding. We want it to be a slice.
+				value := []byte{}
+				bytes, err := hexutil.Decode(methodArgs[i])
+				if err != nil {
+					log.Fatal(err)
+				}
+				copy(value[:], bytes) // nolint:gocritic
+				argData = value
+			}
+		case strings.HasPrefix(v, "string"):
+			{
+				argData = methodArgs[i]
+			}
+		case strings.HasPrefix(v, "bool"):
+			{
+				value, err := strconv.ParseBool(methodArgs[i])
+				if err != nil {
+					log.Fatal(err)
+				}
+				argData = value
+			}
+		}
+		argumentsData = append(argumentsData, argData)
+	}
+
+	abiEncodeData, err := arguments.PackValues(argumentsData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode arguments: %w", err)
+	}
+
+	data = append(data, abiEncodeData...)
+	return data, nil
+}
+
+// contractCallMethodID calculates the first 4 bytes of the method
+// signature for function call on contract
+func contractCallMethodID(methodSig string) ([]byte, error) {
+	fnSignature := []byte(methodSig)
+	hash := sha3.NewLegacyKeccak256()
+	if _, err := hash.Write(fnSignature); err != nil {
+		return nil, err
+	}
+
+	return hash.Sum(nil)[:4], nil
+}

--- a/service/service_construction_test.go
+++ b/service/service_construction_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"math/big"
 	"testing"
 
@@ -1060,6 +1061,102 @@ func TestPreprocessMetadata(t *testing.T) {
 				Data: common.Hex2Bytes(
 					"6e286671000000000000000000000000000000000000000000000000009864aac3510d020000000000000000000000000000000000000000000000000000000000000000",
 				),
+			},
+		).Return(
+			uint64(21001),
+			nil,
+		).Once()
+		client.On(
+			"NonceAt",
+			ctx,
+			common.HexToAddress("0xe3a5B4d7f79d64088C8d4ef153A7DDe2B2d47309"),
+			(*big.Int)(nil),
+		).Return(
+			uint64(0),
+			nil,
+		).Once()
+
+		metadataResponse, err := service.ConstructionMetadata(
+			ctx,
+			&types.ConstructionMetadataRequest{
+				NetworkIdentifier: networkIdentifier,
+				Options:           forceMarshalMap(t, &opt),
+			},
+		)
+		assert.Nil(t, err)
+		assert.Equal(t, &types.ConstructionMetadataResponse{
+			Metadata: forceMarshalMap(t, metadata),
+			SuggestedFee: []*types.Amount{
+				{
+					Value:    "21001000000000",
+					Currency: mapper.AvaxCurrency,
+				},
+			},
+		}, metadataResponse)
+	})
+
+	t.Run("arbitrary contract call flow", func(t *testing.T) {
+		contractCallIntent := `[{"operation_identifier":{"index":0},"type":"CALL","account":{"address":"0xe3a5B4d7f79d64088C8d4ef153A7DDe2B2d47309"},"amount":{"value":"0","currency":{"symbol":"TEST","decimals":18}}},{"operation_identifier":{"index":1},"type":"CALL","account":{"address":"0x57B414a0332B5CaB885a451c2a28a07d1e9b8a8d"},"amount":{"value":"0","currency":{"symbol":"TEST","decimals":18}}}]`
+		service := ConstructionService{
+			config:                &Config{Mode: ModeOnline},
+			client:                client,
+			pChainBackend:         skippedBackend,
+			cChainAtomicTxBackend: skippedBackend,
+		}
+
+		var ops []*types.Operation
+		assert.NoError(t, json.Unmarshal([]byte(contractCallIntent), &ops))
+
+		requestMetadata := map[string]interface{}{
+			"bridge_unwrap":    false,
+			"method_signature": `deploy(bytes32,address,address,address,address)`,
+			"method_args":      []string{"0x3100000000000000000000000000000000000000000000000000000000000000", "0x323e3ab04a3795ad79cc92378fcdb0a0aec51ba5", "0x14e37c2e9cd255404bd35b4542fd9ccaa070aed6", "0x323e3ab04a3795ad79cc92378fcdb0a0aec51ba5", "0x14e37c2e9cd255404bd35b4542fd9ccaa070aed6"},
+		}
+
+		preprocessResponse, err := service.ConstructionPreprocess(
+			ctx,
+			&types.ConstructionPreprocessRequest{
+				NetworkIdentifier: networkIdentifier,
+				Operations:        ops,
+				Metadata:          requestMetadata,
+			},
+		)
+		assert.Nil(t, err)
+
+		optionsRaw := `{"from":"0xe3a5B4d7f79d64088C8d4ef153A7DDe2B2d47309","to":"0x57B414a0332B5CaB885a451c2a28a07d1e9b8a8d","value":"0x0", "currency":{"symbol":"TEST","decimals":18}, "contract_address": "0x57B414a0332B5CaB885a451c2a28a07d1e9b8a8d", "method_signature": "deploy(bytes32,address,address,address,address)", "data": "0xb0d78b753100000000000000000000000000000000000000000000000000000000000000000000000000000000000000323e3ab04a3795ad79cc92378fcdb0a0aec51ba500000000000000000000000014e37c2e9cd255404bd35b4542fd9ccaa070aed6000000000000000000000000323e3ab04a3795ad79cc92378fcdb0a0aec51ba500000000000000000000000014e37c2e9cd255404bd35b4542fd9ccaa070aed6", "method_args":["0x3100000000000000000000000000000000000000000000000000000000000000","0x323e3ab04a3795ad79cc92378fcdb0a0aec51ba5","0x14e37c2e9cd255404bd35b4542fd9ccaa070aed6","0x323e3ab04a3795ad79cc92378fcdb0a0aec51ba5","0x14e37c2e9cd255404bd35b4542fd9ccaa070aed6"] }`
+		var opt options
+		assert.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
+		assert.Equal(t, &types.ConstructionPreprocessResponse{
+			Options: forceMarshalMap(t, &opt),
+		}, preprocessResponse)
+
+		// call metadata API
+		metadata := &metadata{
+			GasPrice:        big.NewInt(1000000000),
+			GasLimit:        21_001,
+			Nonce:           0,
+			UnwrapBridgeTx:  false,
+			ContractData:    "0xb0d78b753100000000000000000000000000000000000000000000000000000000000000000000000000000000000000323e3ab04a3795ad79cc92378fcdb0a0aec51ba500000000000000000000000014e37c2e9cd255404bd35b4542fd9ccaa070aed6000000000000000000000000323e3ab04a3795ad79cc92378fcdb0a0aec51ba500000000000000000000000014e37c2e9cd255404bd35b4542fd9ccaa070aed6",
+			MethodSignature: "deploy(bytes32,address,address,address,address)",
+			MethodArgs:      []string{"0x3100000000000000000000000000000000000000000000000000000000000000", "0x323e3ab04a3795ad79cc92378fcdb0a0aec51ba5", "0x14e37c2e9cd255404bd35b4542fd9ccaa070aed6", "0x323e3ab04a3795ad79cc92378fcdb0a0aec51ba5", "0x14e37c2e9cd255404bd35b4542fd9ccaa070aed6"},
+		}
+
+		client.On(
+			"SuggestGasPrice",
+			ctx,
+		).Return(
+			big.NewInt(1000000000),
+			nil,
+		).Once()
+		contractAddress := common.HexToAddress(defaultToAddress)
+		data, _ := hexutil.Decode("0xb0d78b753100000000000000000000000000000000000000000000000000000000000000000000000000000000000000323e3ab04a3795ad79cc92378fcdb0a0aec51ba500000000000000000000000014e37c2e9cd255404bd35b4542fd9ccaa070aed6000000000000000000000000323e3ab04a3795ad79cc92378fcdb0a0aec51ba500000000000000000000000014e37c2e9cd255404bd35b4542fd9ccaa070aed6")
+		client.On(
+			"EstimateGas",
+			ctx,
+			interfaces.CallMsg{
+				From: common.HexToAddress("0xe3a5B4d7f79d64088C8d4ef153A7DDe2B2d47309"),
+				To:   &contractAddress,
+				Data: data,
 			},
 		).Return(
 			uint64(21001),

--- a/service/types.go
+++ b/service/types.go
@@ -22,6 +22,10 @@ type options struct {
 	Nonce                  *big.Int         `json:"nonce,omitempty"`
 	Currency               *types.Currency  `json:"currency,omitempty"`
 	Metadata               *metadataOptions `json:"metadata,omitempty"`
+	ContractAddress        string           `json:"contract_address,omitempty"`
+	MethodSignature        string           `json:"method_signature,omitempty"`
+	MethodArgs             interface{}      `json:"method_args,omitempty"`
+	ContractData           string           `json:"data,omitempty"`
 }
 
 type optionsWire struct {
@@ -34,6 +38,10 @@ type optionsWire struct {
 	Nonce                  string           `json:"nonce,omitempty"`
 	Currency               *types.Currency  `json:"currency,omitempty"`
 	Metadata               *metadataOptions `json:"metadata,omitempty"`
+	ContractAddress        string           `json:"contract_address,omitempty"`
+	MethodSignature        string           `json:"method_signature,omitempty"`
+	MethodArgs             interface{}      `json:"method_args,omitempty"`
+	ContractData           string           `json:"data,omitempty"`
 }
 
 type metadataOptions struct {
@@ -47,6 +55,9 @@ func (o *options) MarshalJSON() ([]byte, error) {
 		SuggestedFeeMultiplier: o.SuggestedFeeMultiplier,
 		Currency:               o.Currency,
 		Metadata:               o.Metadata,
+		ContractAddress:        o.ContractAddress,
+		MethodSignature:        o.MethodSignature,
+		MethodArgs:             o.MethodArgs,
 	}
 	if o.Value != nil {
 		ow.Value = hexutil.EncodeBig(o.Value)
@@ -59,6 +70,9 @@ func (o *options) MarshalJSON() ([]byte, error) {
 	}
 	if o.Nonce != nil {
 		ow.Nonce = hexutil.EncodeBig(o.Nonce)
+	}
+	if len(o.ContractData) > 0 {
+		ow.ContractData = o.ContractData
 	}
 
 	return json.Marshal(ow)
@@ -74,6 +88,9 @@ func (o *options) UnmarshalJSON(data []byte) error {
 	o.SuggestedFeeMultiplier = ow.SuggestedFeeMultiplier
 	o.Currency = ow.Currency
 	o.Metadata = ow.Metadata
+	o.ContractAddress = ow.ContractAddress
+	o.MethodSignature = ow.MethodSignature
+	o.MethodArgs = ow.MethodArgs
 
 	if len(ow.Value) > 0 {
 		value, err := hexutil.DecodeBig(ow.Value)
@@ -106,30 +123,45 @@ func (o *options) UnmarshalJSON(data []byte) error {
 		}
 		o.Nonce = nonce
 	}
+	if len(ow.ContractData) > 0 {
+		o.ContractData = ow.ContractData
+	}
 
 	return nil
 }
 
 type metadata struct {
-	Nonce          uint64   `json:"nonce"`
-	GasPrice       *big.Int `json:"gas_price"`
-	GasLimit       uint64   `json:"gas_limit"`
-	UnwrapBridgeTx bool     `json:"bridge_unwrap"`
+	Nonce           uint64      `json:"nonce"`
+	GasPrice        *big.Int    `json:"gas_price"`
+	GasLimit        uint64      `json:"gas_limit"`
+	UnwrapBridgeTx  bool        `json:"bridge_unwrap"`
+	ContractData    string      `json:"data,omitempty"`
+	MethodSignature string      `json:"method_signature,omitempty"`
+	MethodArgs      interface{} `json:"method_args,omitempty"`
 }
 
 type metadataWire struct {
-	Nonce          string `json:"nonce"`
-	GasPrice       string `json:"gas_price"`
-	GasLimit       string `json:"gas_limit"`
-	UnwrapBridgeTx bool   `json:"bridge_unwrap"`
+	Nonce           string      `json:"nonce"`
+	GasPrice        string      `json:"gas_price"`
+	GasLimit        string      `json:"gas_limit"`
+	UnwrapBridgeTx  bool        `json:"bridge_unwrap"`
+	ContractData    string      `json:"data,omitempty"`
+	MethodSignature string      `json:"method_signature,omitempty"`
+	MethodArgs      interface{} `json:"method_args,omitempty"`
 }
 
 func (m *metadata) MarshalJSON() ([]byte, error) {
 	mw := &metadataWire{
-		Nonce:          hexutil.Uint64(m.Nonce).String(),
-		GasPrice:       hexutil.EncodeBig(m.GasPrice),
-		GasLimit:       hexutil.Uint64(m.GasLimit).String(),
-		UnwrapBridgeTx: m.UnwrapBridgeTx,
+		Nonce:           hexutil.Uint64(m.Nonce).String(),
+		GasPrice:        hexutil.EncodeBig(m.GasPrice),
+		GasLimit:        hexutil.Uint64(m.GasLimit).String(),
+		UnwrapBridgeTx:  m.UnwrapBridgeTx,
+		MethodSignature: m.MethodSignature,
+		MethodArgs:      m.MethodArgs,
+	}
+
+	if len(m.ContractData) > 0 {
+		mw.ContractData = m.ContractData
 	}
 
 	return json.Marshal(mw)
@@ -142,6 +174,8 @@ func (m *metadata) UnmarshalJSON(data []byte) error {
 	}
 
 	m.UnwrapBridgeTx = mw.UnwrapBridgeTx
+	m.MethodSignature = mw.MethodSignature
+	m.MethodArgs = mw.MethodArgs
 
 	gasPrice, err := hexutil.DecodeBig(mw.GasPrice)
 	if err != nil {
@@ -160,6 +194,10 @@ func (m *metadata) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	m.Nonce = nonce
+
+	if len(mw.ContractData) > 0 {
+		m.ContractData = mw.ContractData
+	}
 
 	return nil
 }


### PR DESCRIPTION
### What
This pr enables arbitrary contract call support in avalanche rosetta implementation by using a utility function for encoding data field for any contract call method and its arguments.

**Note:** We take this less aggressive approach without removing these hardcoded parts for supporting the `unwrap` contract call, we plan to let it handle the `unwrap` call in a followup PR and cleanup relevant hardcoded parts.

### Test
