### PR TITLE
Add more robust `.golangci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v2
         with:
-          version: latest
+          version: v1.56.1
   check_mockgen:
     name: Up-to-date mocks
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,12 +47,12 @@ linters:
     - errorlint
     - exportloopref
     - forbidigo
+    - gci
     - goconst
     - gocritic
     # - goerr113
     - gofmt
     - gofumpt
-    - goimports
     # - gomnd
     - goprintffuncname
     - gosec
@@ -105,8 +105,16 @@ linters-settings:
       - '^(t|b|tb|f)\.(Fatal|Fatalf|Error|Errorf)$(# the require library should be used instead)?'
     # Exclude godoc examples from forbidigo checks.
     exclude_godoc_examples: false
-  goimports:
-    local-prefixes: github.com/ava-labs/avalanche-rosetta
+  gci:
+    sections:
+      - standard
+      - default
+      - blank
+      - dot
+      - prefix(github.com/ava-labs/avalanche-rosetta)
+      - alias
+    skip-generated: true
+    custom-order: true
   gosec:
     excludes:
       - G107 # Url provided to HTTP request as taint input https://securego.io/docs/rules/g107
@@ -117,8 +125,16 @@ linters-settings:
     no-extra-aliases: false
     # List of aliases
     alias:
-      - pkg: github.com/ava-labs/avalanchego/utils/math
-        alias: safemath
+      - pkg: github.com/ava-labs/coreth/core/types
+        alias: ethtypes
+      - pkg: github.com/ethereum/go-ethereum/common
+        alias: ethcommon
+      - pkg: github.com/ava-labs/avalanche-rosetta/mapper/pchain
+        alias: pmapper
+      - pkg: github.com/ava-labs/avalanche-rosetta/mapper/cchainatomictx
+        alias: cmapper
+      - pkg: github.com/ava-labs/avalanchego/utils/constants
+        alias: avaconstants
   revive:
     rules:
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bool-literal-in-expr

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,9 +69,11 @@ linters:
     - prealloc
     - predeclared
     - revive
+    - spancheck
     - staticcheck
     - stylecheck
     - tagalign
+    - testifylint
     - typecheck
     - unconvert
     - unparam
@@ -177,9 +179,32 @@ linters-settings:
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
       - name: useless-break
         disabled: false
+  spancheck:
+    # https://github.com/jjti/go-spancheck#checks
+    checks:
+      - end
+      # - record-error # check that `span.RecordError(err)` is called when an error is returned
+      # - set-status   # check that `span.SetStatus(codes.Error, msg)` is called when an error is returned
   staticcheck:
     # https://staticcheck.io/docs/options#checks
     checks:
       - "all"
       - "-SA6002" # Storing non-pointer values in sync.Pool allocates memory
       - "-SA1019" # Using a deprecated function, variable, constant or field
+  tagalign:
+    align: true
+    sort: true
+    strict: true
+    order:
+      - serialize
+  testifylint:
+    # Enable all checkers (https://github.com/Antonboom/testifylint#checkers).
+    # Default: false
+    enable-all: true
+    # Disable checkers by name
+    # (in addition to default
+    #   suite-thelper
+    # ).
+    disable:
+      - go-require
+      - float-compare

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,67 +1,169 @@
 # https://golangci-lint.run/usage/configuration/
 run:
   timeout: 10m
-  # skip auto-generated files.
-  skip-files:
-    - ".*\\.pb\\.go$"
+
+  # Enables skipping of directories:
+  # - vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  # Default: true
+  skip-dirs-use-default: false
+
+  # If set we pass it to "go list -mod={option}". From "go help modules":
+  # If invoked with -mod=readonly, the go command is disallowed from the implicit
+  # automatic updating of go.mod described above. Instead, it fails when any changes
+  # to go.mod are needed. This setting is most useful to check that go.mod does
+  # not need updates, such as in a continuous integration and testing system.
+  # If invoked with -mod=vendor, the go command assumes that the vendor
+  # directory holds the correct copies of dependencies and ignores
+  # the dependency descriptions in go.mod.
+  #
+  # Allowed values: readonly|vendor|mod
+  # By default, it isn't set.
+  modules-download-mode: readonly
+
+output:
+  # Make issues output unique by line.
+  # Default: true
+  uniq-by-line: false
 
 issues:
-  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  # Maximum issues count per one linter.
+  # Set to 0 to disable.
+  # Default: 50
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
   max-same-issues: 0
-  exclude:
-    - "G114: Use of net/http serve function that has no support for setting timeouts"
-  exclude-rules:
-    # ref: https://github.com/dominikh/go-tools/issues/1365
-    - path: client/pchainclient.go
-      linters:
-        - unused
 
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
   disable-all: true
   enable:
     - asciicheck
     - bodyclose
-    - deadcode
+    - depguard
+    - dupword
     - errcheck
+    - errorlint
     - exportloopref
+    - forbidigo
     - goconst
     - gocritic
+    # - goerr113
     - gofmt
     - gofumpt
     - goimports
-    - revive
+    # - gomnd
+    - goprintffuncname
     - gosec
     - gosimple
     - govet
+    - importas
     - ineffassign
+    # - lll
     - misspell
     - nakedret
+    - noctx
     - nolintlint
+    - perfsprint
     - prealloc
+    - predeclared
+    - revive
+    - staticcheck
     - stylecheck
+    - tagalign
+    - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
-    - unconvert
+    - usestdlibvars
     - whitespace
-    - staticcheck
-    # - structcheck
-    # - lll
-    # - gomnd
-    # - goprintffuncname
-    # - interfacer
-    # - typecheck
-    # - goerr113
-    # - noctx
 
 linters-settings:
+  depguard:
+    rules:
+      packages:
+        deny:
+          - pkg: "io/ioutil"
+            desc: io/ioutil is deprecated. Use package io or os instead.
+          - pkg: "github.com/stretchr/testify/assert"
+            desc: github.com/stretchr/testify/require should be used instead.
+          - pkg: "github.com/golang/mock/gomock"
+            desc: go.uber.org/mock/gomock should be used instead.
+  errorlint:
+    # Check for plain type assertions and type switches.
+    asserts: false
+    # Check for plain error comparisons.
+    comparison: false
+  forbidigo:
+    # Forbid the following identifiers (list of regexp).
+    forbid:
+      - 'require\.Error$(# ErrorIs should be used instead)?'
+      - 'require\.ErrorContains$(# ErrorIs should be used instead)?'
+      - 'require\.EqualValues$(# Equal should be used instead)?'
+      - 'require\.NotEqualValues$(# NotEqual should be used instead)?'
+      - '^(t|b|tb|f)\.(Fatal|Fatalf|Error|Errorf)$(# the require library should be used instead)?'
+    # Exclude godoc examples from forbidigo checks.
+    exclude_godoc_examples: false
+  goimports:
+    local-prefixes: github.com/ava-labs/avalanche-rosetta
+  gosec:
+    excludes:
+      - G107 # Url provided to HTTP request as taint input https://securego.io/docs/rules/g107
+  importas:
+    # Do not allow unaliased imports of aliased packages.
+    no-unaliased: false
+    # Do not allow non-required aliases.
+    no-extra-aliases: false
+    # List of aliases
+    alias:
+      - pkg: github.com/ava-labs/avalanchego/utils/math
+        alias: safemath
+  revive:
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bool-literal-in-expr
+      - name: bool-literal-in-expr
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return
+      - name: early-return
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-lines
+      - name: empty-lines
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#string-format
+      - name: string-format
+        disabled: false
+        arguments:
+        - ["fmt.Errorf[0]", "/.*%.*/", "no format directive, use errors.New instead"]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#struct-tag
+      - name: struct-tag
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-naming
+      - name: unexported-naming
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unhandled-error
+      - name: unhandled-error
+        disabled: false
+        arguments:
+          - "fmt\\.Fprint"
+          - "fmt\\.Fprintf"
+          - "fmt\\.Print"
+          - "fmt\\.Printf"
+          - "fmt\\.Println"
+          - "math/rand\\.Read"
+          - "strings\\.Builder\\.WriteString"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
+      - name: unused-parameter
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver
+      - name: unused-receiver
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
+      - name: useless-break
+        disabled: false
   staticcheck:
-    go: "1.21"
     # https://staticcheck.io/docs/options#checks
     checks:
       - "all"
-      - "-SA6002" # argument should be pointer-like to avoid allocation, for sync.Pool
-      - "-SA1019" # deprecated packages e.g., golang.org/x/crypto/ripemd160
+      - "-SA6002" # Storing non-pointer values in sync.Pool allocates memory
+      - "-SA1019" # Using a deprecated function, variable, constant or field

--- a/client/client.go
+++ b/client/client.go
@@ -5,7 +5,6 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/ava-labs/avalanche-rosetta/constants"
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/rpc"
@@ -13,6 +12,8 @@ import (
 	"github.com/ava-labs/coreth/interfaces"
 	"github.com/ava-labs/coreth/plugin/evm"
 	ethcommon "github.com/ethereum/go-ethereum/common"
+
+	"github.com/ava-labs/avalanche-rosetta/constants"
 )
 
 // Interface compliance

--- a/client/client.go
+++ b/client/client.go
@@ -8,10 +8,10 @@ import (
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/rpc"
-	ethtypes "github.com/ava-labs/coreth/core/types"
+	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/interfaces"
 	"github.com/ava-labs/coreth/plugin/evm"
-	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ava-labs/avalanche-rosetta/constants"
 )
@@ -24,21 +24,21 @@ type Client interface {
 	InfoClient
 
 	ChainID(context.Context) (*big.Int, error)
-	BlockByHash(context.Context, ethcommon.Hash) (*ethtypes.Block, error)
-	BlockByNumber(context.Context, *big.Int) (*ethtypes.Block, error)
-	HeaderByHash(context.Context, ethcommon.Hash) (*ethtypes.Header, error)
-	HeaderByNumber(context.Context, *big.Int) (*ethtypes.Header, error)
-	TransactionByHash(context.Context, ethcommon.Hash) (*ethtypes.Transaction, bool, error)
-	TransactionReceipt(context.Context, ethcommon.Hash) (*ethtypes.Receipt, error)
+	BlockByHash(context.Context, common.Hash) (*types.Block, error)
+	BlockByNumber(context.Context, *big.Int) (*types.Block, error)
+	HeaderByHash(context.Context, common.Hash) (*types.Header, error)
+	HeaderByNumber(context.Context, *big.Int) (*types.Header, error)
+	TransactionByHash(context.Context, common.Hash) (*types.Transaction, bool, error)
+	TransactionReceipt(context.Context, common.Hash) (*types.Receipt, error)
 	TraceTransaction(context.Context, string) (*Call, []*FlatCall, error)
 	TraceBlockByHash(context.Context, string) ([]*Call, [][]*FlatCall, error)
-	SendTransaction(context.Context, *ethtypes.Transaction) error
-	BalanceAt(context.Context, ethcommon.Address, *big.Int) (*big.Int, error)
-	NonceAt(context.Context, ethcommon.Address, *big.Int) (uint64, error)
+	SendTransaction(context.Context, *types.Transaction) error
+	BalanceAt(context.Context, common.Address, *big.Int) (*big.Int, error)
+	NonceAt(context.Context, common.Address, *big.Int) (uint64, error)
 	SuggestGasPrice(context.Context) (*big.Int, error)
 	EstimateGas(context.Context, interfaces.CallMsg) (uint64, error)
 	TxPoolContent(context.Context) (*TxPoolContent, error)
-	GetContractInfo(ethcommon.Address, bool) (string, uint8, error)
+	GetContractInfo(common.Address, bool) (string, uint8, error)
 	CallContract(context.Context, interfaces.CallMsg, *big.Int) ([]byte, error)
 	IssueTx(ctx context.Context, txBytes []byte, options ...rpc.Option) (ids.ID, error)
 	GetAtomicUTXOs(ctx context.Context, addrs []ids.ShortID, sourceChain string, limit uint32, startAddress ids.ShortID, startUTXOID ids.ID, options ...rpc.Option) ([][]byte, ids.ShortID, ids.ID, error)

--- a/client/eth.go
+++ b/client/eth.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ava-labs/coreth/eth/tracers"
 	"github.com/ava-labs/coreth/ethclient"
@@ -24,7 +23,7 @@ type EthClient struct {
 
 // NewEthClient returns a new EVM client
 func NewEthClient(ctx context.Context, endpoint string) (*EthClient, error) {
-	endpointURL := fmt.Sprintf("%s%s", endpoint, prefixEth)
+	endpointURL := endpoint + prefixEth
 
 	c, err := rpc.DialContext(ctx, endpointURL)
 	if err != nil {

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"os"
 
+	"github.com/ava-labs/avalanchego/utils/constants"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/ava-labs/avalanche-rosetta/client"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 	"github.com/ava-labs/avalanche-rosetta/service"
-	"github.com/ava-labs/avalanchego/utils/constants"
 )
 
 var (

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/ava-labs/avalanchego/utils/constants"
-	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ava-labs/avalanche-rosetta/client"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
@@ -97,7 +97,7 @@ func (c *config) validate() error {
 
 	if len(c.TokenWhiteList) != 0 {
 		for _, token := range c.TokenWhiteList {
-			if !ethcommon.IsHexAddress(token) {
+			if !common.IsHexAddress(token) {
 				return errInvalidTokenAddress
 			}
 		}
@@ -105,7 +105,7 @@ func (c *config) validate() error {
 
 	if len(c.BridgeTokenList) != 0 {
 		for _, token := range c.BridgeTokenList {
-			if !ethcommon.IsHexAddress(token) {
+			if !common.IsHexAddress(token) {
 				return errInvalidTokenAddress
 			}
 
@@ -128,7 +128,7 @@ func (c *config) validate() error {
 
 func (c *config) validateWhitelistOnlyValidErc20s(cli client.Client) error {
 	for _, token := range c.TokenWhiteList {
-		ethAddress := ethcommon.HexToAddress(token)
+		ethAddress := common.HexToAddress(token)
 		symbol, decimals, err := cli.GetContractInfo(ethAddress, true)
 		if err != nil {
 			return err

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -30,8 +30,9 @@ var (
 	cmdName    = "avalanche-rosetta"
 	cmdVersion = service.MiddlewareVersion
 
-	defaultReadTimeout  = 10 * time.Second
-	defaultWriteTimeout = 10 * time.Second
+	// This is set moderately high to account for debug_trace calls.
+	defaultReadTimeout  = 3 * time.Minute
+	defaultWriteTimeout = 3 * time.Minute
 )
 
 var opts struct {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -29,6 +29,9 @@ import (
 var (
 	cmdName    = "avalanche-rosetta"
 	cmdVersion = service.MiddlewareVersion
+
+	defaultReadTimeout  = 10 * time.Second
+	defaultWriteTimeout = 10 * time.Second
 )
 
 var opts struct {
@@ -194,9 +197,10 @@ func main() {
 	log.Printf("starting rosetta server at %s\n", cfg.ListenAddr)
 
 	server := &http.Server{
-		Addr:              cfg.ListenAddr,
-		Handler:           router,
-		ReadHeaderTimeout: 30 * time.Second,
+		Addr:         cfg.ListenAddr,
+		Handler:      router,
+		ReadTimeout:  defaultReadTimeout,
+		WriteTimeout: defaultWriteTimeout,
 	}
 
 	log.Fatal(server.ListenAndServe())

--- a/mapper/account.go
+++ b/mapper/account.go
@@ -2,6 +2,7 @@ package mapper
 
 import (
 	"github.com/coinbase/rosetta-sdk-go/types"
+
 	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 

--- a/mapper/account.go
+++ b/mapper/account.go
@@ -2,11 +2,10 @@ package mapper
 
 import (
 	"github.com/coinbase/rosetta-sdk-go/types"
-
-	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common"
 )
 
-func Account(address *ethcommon.Address) *types.AccountIdentifier {
+func Account(address *common.Address) *types.AccountIdentifier {
 	if address == nil {
 		return nil
 	}

--- a/mapper/block.go
+++ b/mapper/block.go
@@ -1,12 +1,12 @@
 package mapper
 
 import (
-	corethTypes "github.com/ava-labs/coreth/core/types"
+	"github.com/ava-labs/coreth/core/types"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 // BlockMetadata returns meta data for a block
-func BlockMetadata(block *corethTypes.Block) map[string]interface{} {
+func BlockMetadata(block *types.Block) map[string]interface{} {
 	meta := map[string]interface{}{
 		"gas_limit":  hexutil.EncodeUint64(block.GasLimit()),
 		"gas_used":   hexutil.EncodeUint64(block.GasUsed()),

--- a/mapper/cchainatomictx/tx_builder.go
+++ b/mapper/cchainatomictx/tx_builder.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ava-labs/coreth/plugin/evm"
 	"github.com/coinbase/rosetta-sdk-go/parser"
 	"github.com/coinbase/rosetta-sdk-go/types"
-	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 )
@@ -89,7 +89,7 @@ func buildIns(matches []*parser.Match, metadata Metadata, avaxAssetID ids.ID) ([
 	signers := []*types.AccountIdentifier{}
 	for i, op := range inputMatch.Operations {
 		ins = append(ins, evm.EVMInput{
-			Address: ethcommon.HexToAddress(op.Account.Address),
+			Address: common.HexToAddress(op.Account.Address),
 			Amount:  inputMatch.Amounts[i].Uint64(),
 			AssetID: avaxAssetID,
 			Nonce:   metadata.Nonce,
@@ -142,7 +142,7 @@ func buildOuts(matches []*parser.Match, avaxAssetID ids.ID) []evm.EVMOutput {
 	outs := []evm.EVMOutput{}
 	for i, op := range outputMatch.Operations {
 		outs = append(outs, evm.EVMOutput{
-			Address: ethcommon.HexToAddress(op.Account.Address),
+			Address: common.HexToAddress(op.Account.Address),
 			Amount:  outputMatch.Amounts[i].Uint64(),
 			AssetID: avaxAssetID,
 		})

--- a/mapper/cchainatomictx/tx_parser.go
+++ b/mapper/cchainatomictx/tx_parser.go
@@ -2,7 +2,6 @@ package cchainatomictx
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strconv"
 
@@ -45,7 +44,7 @@ func (t *TxParser) Parse(tx evm.Tx) ([]*types.Operation, error) {
 	case *evm.UnsignedImportTx:
 		return t.parseImportTx(unsignedTx)
 	default:
-		return nil, fmt.Errorf("unsupported tx type")
+		return nil, errors.New("unsupported tx type")
 	}
 }
 
@@ -83,7 +82,7 @@ func (t *TxParser) parseImportTx(importTx *evm.UnsignedImportTx) ([]*types.Opera
 	return operations, nil
 }
 
-func (t *TxParser) insToOperations(startIdx int64, opType string, ins []evm.EVMInput) []*types.Operation {
+func (*TxParser) insToOperations(startIdx int64, opType string, ins []evm.EVMInput) []*types.Operation {
 	idx := startIdx
 	operations := []*types.Operation{}
 	for _, in := range ins {
@@ -132,7 +131,7 @@ func (t *TxParser) importedInToOperations(startIdx int64, opType string, ins []*
 	return operations, nil
 }
 
-func (t *TxParser) outsToOperations(startIdx int, opType string, outs []evm.EVMOutput) []*types.Operation {
+func (*TxParser) outsToOperations(startIdx int, opType string, outs []evm.EVMOutput) []*types.Operation {
 	idx := startIdx
 	operations := []*types.Operation{}
 	for _, out := range outs {

--- a/mapper/cchainatomictx/tx_parser.go
+++ b/mapper/cchainatomictx/tx_parser.go
@@ -50,7 +50,7 @@ func (t *TxParser) Parse(tx evm.Tx) ([]*types.Operation, error) {
 
 func (t *TxParser) parseExportTx(exportTx *evm.UnsignedExportTx) ([]*types.Operation, error) {
 	operations := []*types.Operation{}
-	ins := t.insToOperations(0, mapper.OpExport, exportTx.Ins)
+	ins := insToOperations(0, mapper.OpExport, exportTx.Ins)
 
 	destinationChainID := exportTx.DestinationChain
 	chainAlias, ok := t.chainIDs[destinationChainID]
@@ -82,7 +82,7 @@ func (t *TxParser) parseImportTx(importTx *evm.UnsignedImportTx) ([]*types.Opera
 	return operations, nil
 }
 
-func (*TxParser) insToOperations(startIdx int64, opType string, ins []evm.EVMInput) []*types.Operation {
+func insToOperations(startIdx int64, opType string, ins []evm.EVMInput) []*types.Operation {
 	idx := startIdx
 	operations := []*types.Operation{}
 	for _, in := range ins {

--- a/mapper/cchainatomictx/tx_parser.go
+++ b/mapper/cchainatomictx/tx_parser.go
@@ -76,7 +76,7 @@ func (t *TxParser) parseImportTx(importTx *evm.UnsignedImportTx) ([]*types.Opera
 	}
 
 	operations = append(operations, ins...)
-	outs := t.outsToOperations(len(ins), mapper.OpImport, importTx.Outs)
+	outs := outsToOperations(len(ins), mapper.OpImport, importTx.Outs)
 	operations = append(operations, outs...)
 
 	return operations, nil
@@ -131,7 +131,7 @@ func (t *TxParser) importedInToOperations(startIdx int64, opType string, ins []*
 	return operations, nil
 }
 
-func (*TxParser) outsToOperations(startIdx int, opType string, outs []evm.EVMOutput) []*types.Operation {
+func outsToOperations(startIdx int, opType string, outs []evm.EVMOutput) []*types.Operation {
 	idx := startIdx
 	operations := []*types.Operation{}
 	for _, out := range outs {

--- a/mapper/helper.go
+++ b/mapper/helper.go
@@ -72,7 +72,7 @@ func MarshalJSONMap(i interface{}) (map[string]interface{}, error) {
 func DecodeUTXOID(s string) (*avax.UTXOID, error) {
 	split := strings.Split(s, ":")
 	if len(split) != 2 {
-		return nil, fmt.Errorf("invalid utxo ID format")
+		return nil, errors.New("invalid utxo ID format")
 	}
 
 	txID, err := ids.FromString(split[0])

--- a/mapper/pchain/tx_builder.go
+++ b/mapper/pchain/tx_builder.go
@@ -281,7 +281,7 @@ func buildInputs(
 	err error,
 ) {
 	for _, op := range operations {
-		UTXOID, err := mapper.DecodeUTXOID(op.CoinChange.CoinIdentifier.Identifier)
+		utxoID, err := mapper.DecodeUTXOID(op.CoinChange.CoinIdentifier.Identifier)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to decode UTXO ID: %w", err)
 		}
@@ -297,7 +297,7 @@ func buildInputs(
 		}
 
 		in := &avax.TransferableInput{
-			UTXOID: *UTXOID,
+			UTXOID: *utxoID,
 			Asset:  avax.Asset{ID: avaxAssetID},
 			In: &secp256k1fx.TransferInput{
 				Amt: val.Uint64(),

--- a/mapper/pchain/tx_dependency.go
+++ b/mapper/pchain/tx_dependency.go
@@ -18,7 +18,7 @@ type BlockTxDependencies map[ids.ID]*SingleTxDependency
 // GetTxDependenciesIDs generates the list of transaction ids used in the inputs to given unsigned transaction
 // this list is then used to fetch the dependency transactions in order to extract source addresses
 // as this information is not part of the transaction objects on chain.
-func (bd BlockTxDependencies) GetTxDependenciesIDs(tx txs.UnsignedTx) ([]ids.ID, error) {
+func (BlockTxDependencies) GetTxDependenciesIDs(tx txs.UnsignedTx) ([]ids.ID, error) {
 	// collect tx inputs
 	var ins []*avax.TransferableInput
 	switch unsignedTx := tx.(type) {

--- a/mapper/pchain/tx_dependency.go
+++ b/mapper/pchain/tx_dependency.go
@@ -18,7 +18,7 @@ type BlockTxDependencies map[ids.ID]*SingleTxDependency
 // GetTxDependenciesIDs generates the list of transaction ids used in the inputs to given unsigned transaction
 // this list is then used to fetch the dependency transactions in order to extract source addresses
 // as this information is not part of the transaction objects on chain.
-func (BlockTxDependencies) GetTxDependenciesIDs(tx txs.UnsignedTx) ([]ids.ID, error) {
+func GetTxDependenciesIDs(tx txs.UnsignedTx) ([]ids.ID, error) {
 	// collect tx inputs
 	var ins []*avax.TransferableInput
 	switch unsignedTx := tx.(type) {

--- a/mapper/pchain/tx_dependency_test.go
+++ b/mapper/pchain/tx_dependency_test.go
@@ -80,7 +80,7 @@ func TestTxDependencyIsCreateChain(t *testing.T) {
 
 	dep := &SingleTxDependency{Tx: tx}
 	res := dep.GetUtxos()
-	require.True(len(res) == 2)
+	require.Len(res, 2)
 
 	expectedUTXOs := []*avax.UTXO{
 		{
@@ -183,7 +183,7 @@ func TestTxDependencyIsAddValidator(t *testing.T) {
 
 	dep := &SingleTxDependency{Tx: tx}
 	res := dep.GetUtxos()
-	require.True(len(res) == 2)
+	require.Len(res, 2)
 
 	expectedUTXOs := []*avax.UTXO{
 		{

--- a/mapper/pchain/tx_parser_test.go
+++ b/mapper/pchain/tx_parser_test.go
@@ -5,23 +5,24 @@ import (
 	"testing"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanche-rosetta/client"
-	rosConst "github.com/ava-labs/avalanche-rosetta/constants"
+	"github.com/ava-labs/avalanche-rosetta/constants"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
+
+	avaconstants "github.com/ava-labs/avalanchego/utils/constants"
 )
 
 var (
 	avaxAssetID, _ = ids.FromString("U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK")
 	cChainID, _    = ids.FromString("yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp")
-	chainIDs       = map[ids.ID]rosConst.ChainIDAlias{
-		ids.Empty: rosConst.PChain,
-		cChainID:  rosConst.CChain,
+	chainIDs       = map[ids.ID]constants.ChainIDAlias{
+		ids.Empty: constants.PChain,
+		cChainID:  constants.CChain,
 	}
 )
 
@@ -37,7 +38,7 @@ func TestMapInOperation(t *testing.T) {
 	pchainClient := client.NewMockPChainClient(ctrl)
 	parserCfg := TxParserConfig{
 		IsConstruction: false,
-		Hrp:            constants.FujiHRP,
+		Hrp:            avaconstants.FujiHRP,
 		ChainIDs:       chainIDs,
 		AvaxAssetID:    avaxAssetID,
 		PChainClient:   pchainClient,
@@ -89,7 +90,7 @@ func TestMapNonAvaxTransactionInConstruction(t *testing.T) {
 	pchainClient := client.NewMockPChainClient(ctrl)
 	parserCfg := TxParserConfig{
 		IsConstruction: true,
-		Hrp:            constants.FujiHRP,
+		Hrp:            avaconstants.FujiHRP,
 		ChainIDs:       chainIDs,
 
 		// passing empty as AVAX id, so that
@@ -118,7 +119,7 @@ func TestMapOutOperation(t *testing.T) {
 	pchainClient := client.NewMockPChainClient(ctrl)
 	parserCfg := TxParserConfig{
 		IsConstruction: true,
-		Hrp:            constants.FujiHRP,
+		Hrp:            avaconstants.FujiHRP,
 		ChainIDs:       chainIDs,
 		AvaxAssetID:    avaxAssetID,
 		PChainClient:   pchainClient,
@@ -126,7 +127,7 @@ func TestMapOutOperation(t *testing.T) {
 	parser, err := NewTxParser(parserCfg, inputAccounts, nil)
 	require.NoError(err)
 	outOps := newTxOps(false)
-	require.NoError(parser.outsToOperations(outOps, OpAddDelegator, ids.Empty, []*avax.TransferableOutput{avaxOut}, OpTypeOutput, rosConst.PChain))
+	require.NoError(parser.outsToOperations(outOps, OpAddDelegator, ids.Empty, []*avax.TransferableOutput{avaxOut}, OpTypeOutput, constants.PChain))
 
 	rosettaOutOp := outOps.Outs
 
@@ -155,7 +156,7 @@ func TestMapAddValidatorTx(t *testing.T) {
 	pchainClient := client.NewMockPChainClient(ctrl)
 	parserCfg := TxParserConfig{
 		IsConstruction: true,
-		Hrp:            constants.FujiHRP,
+		Hrp:            avaconstants.FujiHRP,
 		ChainIDs:       chainIDs,
 		AvaxAssetID:    avaxAssetID,
 		PChainClient:   pchainClient,
@@ -189,7 +190,7 @@ func TestMapAddDelegatorTx(t *testing.T) {
 	pchainClient := client.NewMockPChainClient(ctrl)
 	parserCfg := TxParserConfig{
 		IsConstruction: true,
-		Hrp:            constants.FujiHRP,
+		Hrp:            avaconstants.FujiHRP,
 		ChainIDs:       chainIDs,
 		AvaxAssetID:    avaxAssetID,
 		PChainClient:   pchainClient,
@@ -240,7 +241,7 @@ func TestMapImportTx(t *testing.T) {
 	pchainClient := client.NewMockPChainClient(ctrl)
 	parserCfg := TxParserConfig{
 		IsConstruction: true,
-		Hrp:            constants.FujiHRP,
+		Hrp:            avaconstants.FujiHRP,
 		ChainIDs:       chainIDs,
 		AvaxAssetID:    avaxAssetID,
 		PChainClient:   pchainClient,
@@ -277,7 +278,7 @@ func TestMapNonConstructionImportTx(t *testing.T) {
 	pchainClient := client.NewMockPChainClient(ctrl)
 	parserCfg := TxParserConfig{
 		IsConstruction: false,
-		Hrp:            constants.FujiHRP,
+		Hrp:            avaconstants.FujiHRP,
 		ChainIDs:       chainIDs,
 		AvaxAssetID:    avaxAssetID,
 		PChainClient:   pchainClient,
@@ -335,7 +336,7 @@ func TestMapExportTx(t *testing.T) {
 	pchainClient := client.NewMockPChainClient(ctrl)
 	parserCfg := TxParserConfig{
 		IsConstruction: true,
-		Hrp:            constants.FujiHRP,
+		Hrp:            avaconstants.FujiHRP,
 		ChainIDs:       chainIDs,
 		AvaxAssetID:    avaxAssetID,
 		PChainClient:   pchainClient,
@@ -369,7 +370,7 @@ func TestMapNonConstructionExportTx(t *testing.T) {
 	pchainClient := client.NewMockPChainClient(ctrl)
 	parserCfg := TxParserConfig{
 		IsConstruction: false,
-		Hrp:            constants.FujiHRP,
+		Hrp:            avaconstants.FujiHRP,
 		ChainIDs:       chainIDs,
 		AvaxAssetID:    avaxAssetID,
 		PChainClient:   pchainClient,
@@ -400,7 +401,7 @@ func TestMapNonConstructionExportTx(t *testing.T) {
 	// setting isConstruction to true in order to include exported output in the operations
 	parserCfg = TxParserConfig{
 		IsConstruction: true,
-		Hrp:            constants.FujiHRP,
+		Hrp:            avaconstants.FujiHRP,
 		ChainIDs:       chainIDs,
 		AvaxAssetID:    avaxAssetID,
 		PChainClient:   pchainClient,

--- a/mapper/pchain/tx_parser_test.go
+++ b/mapper/pchain/tx_parser_test.go
@@ -173,7 +173,7 @@ func TestMapAddValidatorTx(t *testing.T) {
 
 	require.Equal(3, cntTxType)
 	require.Equal(2, cntInputMeta)
-	require.Equal(0, cntOutputMeta)
+	require.Zero(cntOutputMeta)
 	require.Equal(1, cntMetaType)
 }
 
@@ -388,7 +388,7 @@ func TestMapNonConstructionExportTx(t *testing.T) {
 	require.Equal(2, cntTxType)
 	require.Equal(1, cntInputMeta)
 	require.Equal(1, cntOutputMeta)
-	require.Equal(0, cntMetaType)
+	require.Zero(cntMetaType)
 
 	txType, ok := rosettaTransaction.Metadata[MetadataTxType].(string)
 	require.True(ok)

--- a/mapper/peers.go
+++ b/mapper/peers.go
@@ -1,9 +1,8 @@
 package mapper
 
 import (
-	"github.com/coinbase/rosetta-sdk-go/types"
-
 	"github.com/ava-labs/avalanchego/api/info"
+	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
 func Peers(peers []info.Peer) []*types.Peer {

--- a/mapper/transaction.go
+++ b/mapper/transaction.go
@@ -447,7 +447,7 @@ func traceOps(trace []*clientTypes.FlatCall, startIndex int) []*types.Operation 
 		if call.Type == OpSelfDestruct {
 			destroyedAccounts[from] = new(big.Int)
 
-			// If destination of of SELFDESTRUCT is self,
+			// If destination of SELFDESTRUCT is self,
 			// we should skip. In the EVM, the balance is reset
 			// after the balance is increased on the destination
 			// so this is a no-op.

--- a/mapper/transaction_test.go
+++ b/mapper/transaction_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
-	ethtypes "github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/plugin/evm"
 	"github.com/coinbase/rosetta-sdk-go/types"
-	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanche-rosetta/constants"
+
+	ethtypes "github.com/ava-labs/coreth/core/types"
 )
 
 var WAVAX = &types.Currency{
@@ -26,19 +27,19 @@ var WAVAX = &types.Currency{
 }
 
 func TestZeroAddress(t *testing.T) {
-	require.Equal(t, ethcommon.HexToAddress("0x0000000000000000000000000000000000000000"), zeroAddress)
+	require.Equal(t, common.HexToAddress("0x0000000000000000000000000000000000000000"), zeroAddress)
 }
 
 func TestERC20Ops(t *testing.T) {
 	t.Run("transfer op", func(t *testing.T) {
 		log := &ethtypes.Log{
-			Address: ethcommon.HexToAddress("0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7"),
-			Topics: []ethcommon.Hash{
-				ethcommon.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
-				ethcommon.HexToHash("0x000000000000000000000000f1b77573a8525acfa116a785092d1ba90d96bf37"),
-				ethcommon.HexToHash("0x0000000000000000000000005d95ae932d42e53bb9da4de65e9b7263a4fa8564"),
+			Address: common.HexToAddress("0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7"),
+			Topics: []common.Hash{
+				common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
+				common.HexToHash("0x000000000000000000000000f1b77573a8525acfa116a785092d1ba90d96bf37"),
+				common.HexToHash("0x0000000000000000000000005d95ae932d42e53bb9da4de65e9b7263a4fa8564"),
 			},
-			Data: ethcommon.FromHex("0x0000000000000000000000000000000000000000000009513ea9de0243800000"),
+			Data: common.FromHex("0x0000000000000000000000000000000000000000000009513ea9de0243800000"),
 		}
 
 		require.Equal(t, []*types.Operation{
@@ -80,13 +81,13 @@ func TestERC20Ops(t *testing.T) {
 
 	t.Run("burn op", func(t *testing.T) {
 		log := &ethtypes.Log{
-			Address: ethcommon.HexToAddress("0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7"),
-			Topics: []ethcommon.Hash{
-				ethcommon.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
-				ethcommon.HexToHash("0x000000000000000000000000f1b77573a8525acfa116a785092d1ba90d96bf37"),
-				ethcommon.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
+			Address: common.HexToAddress("0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7"),
+			Topics: []common.Hash{
+				common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
+				common.HexToHash("0x000000000000000000000000f1b77573a8525acfa116a785092d1ba90d96bf37"),
+				common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
 			},
-			Data: ethcommon.FromHex("0x0000000000000000000000000000000000000000000009513ea9de0243800000"),
+			Data: common.FromHex("0x0000000000000000000000000000000000000000000009513ea9de0243800000"),
 		}
 
 		require.Equal(t, []*types.Operation{
@@ -109,13 +110,13 @@ func TestERC20Ops(t *testing.T) {
 
 	t.Run("mint op", func(t *testing.T) {
 		log := &ethtypes.Log{
-			Address: ethcommon.HexToAddress("0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7"),
-			Topics: []ethcommon.Hash{
-				ethcommon.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
-				ethcommon.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
-				ethcommon.HexToHash("0x000000000000000000000000f1b77573a8525acfa116a785092d1ba90d96bf37"),
+			Address: common.HexToAddress("0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7"),
+			Topics: []common.Hash{
+				common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
+				common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
+				common.HexToHash("0x000000000000000000000000f1b77573a8525acfa116a785092d1ba90d96bf37"),
 			},
-			Data: ethcommon.FromHex("0x0000000000000000000000000000000000000000000009513ea9de0243800000"),
+			Data: common.FromHex("0x0000000000000000000000000000000000000000000009513ea9de0243800000"),
 		}
 
 		require.Equal(t, []*types.Operation{
@@ -140,12 +141,12 @@ func TestERC20Ops(t *testing.T) {
 func TestERC721Ops(t *testing.T) {
 	t.Run("transfer op", func(t *testing.T) {
 		log := &ethtypes.Log{
-			Address: ethcommon.HexToAddress("0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7"),
-			Topics: []ethcommon.Hash{
-				ethcommon.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
-				ethcommon.HexToHash("0x000000000000000000000000f1b77573a8525acfa116a785092d1ba90d96bf37"),
-				ethcommon.HexToHash("0x0000000000000000000000005d95ae932d42e53bb9da4de65e9b7263a4fa8564"),
-				ethcommon.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000051"),
+			Address: common.HexToAddress("0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7"),
+			Topics: []common.Hash{
+				common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
+				common.HexToHash("0x000000000000000000000000f1b77573a8525acfa116a785092d1ba90d96bf37"),
+				common.HexToHash("0x0000000000000000000000005d95ae932d42e53bb9da4de65e9b7263a4fa8564"),
+				common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000051"),
 			},
 		}
 
@@ -188,12 +189,12 @@ func TestERC721Ops(t *testing.T) {
 
 	t.Run("burn op", func(t *testing.T) {
 		log := &ethtypes.Log{
-			Address: ethcommon.HexToAddress("0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7"),
-			Topics: []ethcommon.Hash{
-				ethcommon.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
-				ethcommon.HexToHash("0x000000000000000000000000f1b77573a8525acfa116a785092d1ba90d96bf37"),
-				ethcommon.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
-				ethcommon.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000051"),
+			Address: common.HexToAddress("0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7"),
+			Topics: []common.Hash{
+				common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
+				common.HexToHash("0x000000000000000000000000f1b77573a8525acfa116a785092d1ba90d96bf37"),
+				common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
+				common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000051"),
 			},
 		}
 
@@ -217,12 +218,12 @@ func TestERC721Ops(t *testing.T) {
 
 	t.Run("mint op", func(t *testing.T) {
 		log := &ethtypes.Log{
-			Address: ethcommon.HexToAddress("0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7"),
-			Topics: []ethcommon.Hash{
-				ethcommon.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
-				ethcommon.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
-				ethcommon.HexToHash("0x000000000000000000000000f1b77573a8525acfa116a785092d1ba90d96bf37"),
-				ethcommon.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000051"),
+			Address: common.HexToAddress("0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7"),
+			Topics: []common.Hash{
+				common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
+				common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
+				common.HexToHash("0x000000000000000000000000f1b77573a8525acfa116a785092d1ba90d96bf37"),
+				common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000051"),
 			},
 		}
 

--- a/mapper/transaction_test.go
+++ b/mapper/transaction_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ava-labs/coreth/plugin/evm"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	ethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanche-rosetta/constants"
 )
@@ -26,9 +26,7 @@ var WAVAX = &types.Currency{
 }
 
 func TestZeroAddress(t *testing.T) {
-	t.Run("correct address", func(t *testing.T) {
-		assert.Equal(t, ethcommon.HexToAddress("0x0000000000000000000000000000000000000000"), zeroAddress)
-	})
+	require.Equal(t, ethcommon.HexToAddress("0x0000000000000000000000000000000000000000"), zeroAddress)
 }
 
 func TestERC20Ops(t *testing.T) {
@@ -43,7 +41,7 @@ func TestERC20Ops(t *testing.T) {
 			Data: ethcommon.FromHex("0x0000000000000000000000000000000000000000000009513ea9de0243800000"),
 		}
 
-		assert.Equal(t, []*types.Operation{
+		require.Equal(t, []*types.Operation{
 			{
 				OperationIdentifier: &types.OperationIdentifier{
 					Index: 1,
@@ -91,7 +89,7 @@ func TestERC20Ops(t *testing.T) {
 			Data: ethcommon.FromHex("0x0000000000000000000000000000000000000000000009513ea9de0243800000"),
 		}
 
-		assert.Equal(t, []*types.Operation{
+		require.Equal(t, []*types.Operation{
 			{
 				OperationIdentifier: &types.OperationIdentifier{
 					Index: 1,
@@ -120,7 +118,7 @@ func TestERC20Ops(t *testing.T) {
 			Data: ethcommon.FromHex("0x0000000000000000000000000000000000000000000009513ea9de0243800000"),
 		}
 
-		assert.Equal(t, []*types.Operation{
+		require.Equal(t, []*types.Operation{
 			{
 				OperationIdentifier: &types.OperationIdentifier{
 					Index: 1,
@@ -151,7 +149,7 @@ func TestERC721Ops(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, []*types.Operation{
+		require.Equal(t, []*types.Operation{
 			{
 				OperationIdentifier: &types.OperationIdentifier{
 					Index: 1,
@@ -199,7 +197,7 @@ func TestERC721Ops(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, []*types.Operation{
+		require.Equal(t, []*types.Operation{
 			{
 				OperationIdentifier: &types.OperationIdentifier{
 					Index: 1,
@@ -228,7 +226,7 @@ func TestERC721Ops(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, []*types.Operation{
+		require.Equal(t, []*types.Operation{
 			{
 				OperationIdentifier: &types.OperationIdentifier{
 					Index: 1,
@@ -248,131 +246,131 @@ func TestERC721Ops(t *testing.T) {
 }
 
 func TestCrossChainImportedInputs(t *testing.T) {
-	t.Run("Cross chain imported input in metadata", func(t *testing.T) {
-		var (
-			rawIdx      = 0
-			avaxAssetID = "U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK"
-			hexTx       = "0x000000000000000000057fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d5000000000000000000000000000000000000000000000000000000000000000000000001d4e3812503247f042cc9bbb3395ceca49e28687726489b0ea2d4dd259fadb8b6000000003d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa0000000500000000772651c00000000100000000000000013158e80abd5a1e1aa716003c9db096792c37962100000000772209123d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa000000010000000900000001309767786d3c3548f34373c858f2bab210c6bd6c837d069e314930273d32acc361e86a05bc5bd251e4cb5809bbca7680361ed3263ff5ba2aa467294bfa000aef00cfb71da5"
-			decodeTx, _ = formatting.Decode(formatting.Hex, hexTx)
-			tx          = &evm.Tx{}
+	require := require.New(t)
 
-			networkIdentifier = &types.NetworkIdentifier{
-				Network: constants.FujiNetwork,
-			}
-			chainIDToAliasMapping = map[ids.ID]constants.ChainIDAlias{
-				ids.Empty: constants.PChain,
-			}
-		)
+	var (
+		rawIdx      = 0
+		avaxAssetID = "U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK"
+		hexTx       = "0x000000000000000000057fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d5000000000000000000000000000000000000000000000000000000000000000000000001d4e3812503247f042cc9bbb3395ceca49e28687726489b0ea2d4dd259fadb8b6000000003d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa0000000500000000772651c00000000100000000000000013158e80abd5a1e1aa716003c9db096792c37962100000000772209123d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa000000010000000900000001309767786d3c3548f34373c858f2bab210c6bd6c837d069e314930273d32acc361e86a05bc5bd251e4cb5809bbca7680361ed3263ff5ba2aa467294bfa000aef00cfb71da5"
+		decodeTx, _ = formatting.Decode(formatting.Hex, hexTx)
+		tx          = &evm.Tx{}
 
-		_, err := evm.Codec.Unmarshal(decodeTx, tx)
-		assert.Nil(t, err)
-		ops, metadata, err := crossChainTransaction(networkIdentifier, chainIDToAliasMapping, rawIdx, avaxAssetID, tx)
-		assert.Nil(t, err)
-		assert.Nil(t, metadata[MetadataExportedOutputs])
-		assert.Equal(t, AtomicAvaxAmount(big.NewInt(280750)), metadata[MetadataTxFee])
+		networkIdentifier = &types.NetworkIdentifier{
+			Network: constants.FujiNetwork,
+		}
+		chainIDToAliasMapping = map[ids.ID]constants.ChainIDAlias{
+			ids.Empty: constants.PChain,
+		}
+	)
 
-		unsignedImportTx := tx.UnsignedAtomicTx.(*evm.UnsignedImportTx)
-		assert.Equal(t, []*types.Operation{
-			{
-				OperationIdentifier: &types.OperationIdentifier{
-					Index: 0,
-				},
-				Type:   OpImport,
-				Status: types.String(StatusSuccess),
-				Account: &types.AccountIdentifier{
-					Address: "0x3158e80abD5A1e1aa716003C9Db096792C379621",
-				},
-				Amount: &types.Amount{
-					Value:    "1998719250000000000",
-					Currency: AvaxCurrency,
-				},
-				Metadata: map[string]interface{}{
-					"asset_id":      "U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK",
-					"blockchain_id": "yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp",
-					"meta":          unsignedImportTx.Metadata,
-					"network_id":    uint32(5),
-					"source_chain":  "11111111111111111111111111111111LpoYY",
-					"tx":            "G8BG8APvViEryMzeEMb4YM49TtZeozLPsQ8aR44aZf7waGWJR",
-					"tx_ids":        []string{"2ckxSTK6TbZuC2kwoTD5QWmwiGCq4EXMGQpZWcdJK2ye9v4dSE"},
-				},
+	_, err := evm.Codec.Unmarshal(decodeTx, tx)
+	require.NoError(err)
+	ops, metadata, err := crossChainTransaction(networkIdentifier, chainIDToAliasMapping, rawIdx, avaxAssetID, tx)
+	require.NoError(err)
+	require.Nil(metadata[MetadataExportedOutputs])
+	require.Equal(AtomicAvaxAmount(big.NewInt(280750)), metadata[MetadataTxFee])
+
+	unsignedImportTx := tx.UnsignedAtomicTx.(*evm.UnsignedImportTx)
+	require.Equal([]*types.Operation{
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: 0,
 			},
-		}, ops)
-	})
+			Type:   OpImport,
+			Status: types.String(StatusSuccess),
+			Account: &types.AccountIdentifier{
+				Address: "0x3158e80abD5A1e1aa716003C9Db096792C379621",
+			},
+			Amount: &types.Amount{
+				Value:    "1998719250000000000",
+				Currency: AvaxCurrency,
+			},
+			Metadata: map[string]interface{}{
+				"asset_id":      "U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK",
+				"blockchain_id": "yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp",
+				"meta":          unsignedImportTx.Metadata,
+				"network_id":    uint32(5),
+				"source_chain":  "11111111111111111111111111111111LpoYY",
+				"tx":            "G8BG8APvViEryMzeEMb4YM49TtZeozLPsQ8aR44aZf7waGWJR",
+				"tx_ids":        []string{"2ckxSTK6TbZuC2kwoTD5QWmwiGCq4EXMGQpZWcdJK2ye9v4dSE"},
+			},
+		},
+	}, ops)
 }
 
 func TestCrossChainExportedOuts(t *testing.T) {
-	t.Run("Cross chain exported outputs in metadata", func(t *testing.T) {
-		var (
-			rawIdx      = 0
-			avaxAssetID = "U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK"
-			hexTx       = "000000000001000000057fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d50000000000000000000000000000000000000000000000000000000000000000000000013158e80abd5a1e1aa716003c9db096792c3796210000000000138aee3d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa000000000000003b000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa0000000700000000000f424000000000000000000000000100000001c83ea4dc195a9275a349e4f616cbb45e23eab2fb00000001000000090000000167fb4fdaa15ce6804e680dc182f0e702259e6f9572a9f5fe0fc6053094951f612a3d9e8128d08be17ae5122d1790160ac8f2e6d21c4b7dde702624eb6219de7301"
-			decodeTx, _ = hex.DecodeString(hexTx)
-			tx          = &evm.Tx{}
+	require := require.New(t)
 
-			networkIdentifier = &types.NetworkIdentifier{
-				Network: constants.FujiNetwork,
-			}
-			chainIDToAliasMapping = map[ids.ID]constants.ChainIDAlias{
-				ids.Empty: constants.PChain,
-			}
-			metaBytes, _         = hex.DecodeString("000000000001000000057fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d50000000000000000000000000000000000000000000000000000000000000000000000013158e80abd5a1e1aa716003c9db096792c3796210000000000138aee3d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa000000000000003b000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa0000000700000000000f424000000000000000000000000100000001c83ea4dc195a9275a349e4f616cbb45e23eab2fb00000001000000090000000167fb4fdaa15ce6804e680dc182f0e702259e6f9572a9f5fe0fc6053094951f612a3d9e8128d08be17ae5122d1790160ac8f2e6d21c4b7dde702624eb6219de7301")
-			metaUnsignedBytes, _ = hex.DecodeString("000000000001000000057fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d50000000000000000000000000000000000000000000000000000000000000000000000013158e80abd5a1e1aa716003c9db096792c3796210000000000138aee3d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa000000000000003b000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa0000000700000000000f424000000000000000000000000100000001c83ea4dc195a9275a349e4f616cbb45e23eab2fb")
-			meta                 = &avax.Metadata{}
-		)
+	var (
+		rawIdx      = 0
+		avaxAssetID = "U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK"
+		hexTx       = "000000000001000000057fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d50000000000000000000000000000000000000000000000000000000000000000000000013158e80abd5a1e1aa716003c9db096792c3796210000000000138aee3d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa000000000000003b000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa0000000700000000000f424000000000000000000000000100000001c83ea4dc195a9275a349e4f616cbb45e23eab2fb00000001000000090000000167fb4fdaa15ce6804e680dc182f0e702259e6f9572a9f5fe0fc6053094951f612a3d9e8128d08be17ae5122d1790160ac8f2e6d21c4b7dde702624eb6219de7301"
+		decodeTx, _ = hex.DecodeString(hexTx)
+		tx          = &evm.Tx{}
 
-		meta.Initialize(metaUnsignedBytes, metaBytes)
-		_, err := evm.Codec.Unmarshal(decodeTx, tx)
-		assert.Nil(t, err)
-		ops, metadata, err := crossChainTransaction(networkIdentifier, chainIDToAliasMapping, rawIdx, avaxAssetID, tx)
-		assert.Nil(t, err)
-		assert.Equal(t, AtomicAvaxAmount(big.NewInt(280750)), metadata[MetadataTxFee])
+		networkIdentifier = &types.NetworkIdentifier{
+			Network: constants.FujiNetwork,
+		}
+		chainIDToAliasMapping = map[ids.ID]constants.ChainIDAlias{
+			ids.Empty: constants.PChain,
+		}
+		metaBytes, _         = hex.DecodeString("000000000001000000057fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d50000000000000000000000000000000000000000000000000000000000000000000000013158e80abd5a1e1aa716003c9db096792c3796210000000000138aee3d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa000000000000003b000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa0000000700000000000f424000000000000000000000000100000001c83ea4dc195a9275a349e4f616cbb45e23eab2fb00000001000000090000000167fb4fdaa15ce6804e680dc182f0e702259e6f9572a9f5fe0fc6053094951f612a3d9e8128d08be17ae5122d1790160ac8f2e6d21c4b7dde702624eb6219de7301")
+		metaUnsignedBytes, _ = hex.DecodeString("000000000001000000057fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d50000000000000000000000000000000000000000000000000000000000000000000000013158e80abd5a1e1aa716003c9db096792c3796210000000000138aee3d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa000000000000003b000000013d9bdac0ed1d761330cf680efdeb1a42159eb387d6d2950c96f7d28f61bbe2aa0000000700000000000f424000000000000000000000000100000001c83ea4dc195a9275a349e4f616cbb45e23eab2fb")
+		meta                 = &avax.Metadata{}
+	)
 
-		assert.Equal(t, []*types.Operation{
-			{
-				OperationIdentifier: &types.OperationIdentifier{
-					Index: 0,
-				},
-				Type:   OpExport,
-				Status: types.String(StatusSuccess),
-				Account: &types.AccountIdentifier{
-					Address: "0x3158e80abD5A1e1aa716003C9Db096792C379621",
-				},
-				Amount: &types.Amount{
-					Value:    "-1280750000000000",
-					Currency: AvaxCurrency,
-				},
-				Metadata: map[string]interface{}{
-					"tx":                "7QUPqUAMdny53bVptZ2DgxLLN4qZ5X7MnBPseUKYnoh5C5v47",
-					"blockchain_id":     "yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp",
-					"network_id":        uint32(5),
-					"destination_chain": "11111111111111111111111111111111LpoYY",
-					"meta":              *meta,
-					"asset_id":          "U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK",
-				},
+	meta.Initialize(metaUnsignedBytes, metaBytes)
+	_, err := evm.Codec.Unmarshal(decodeTx, tx)
+	require.NoError(err)
+	ops, metadata, err := crossChainTransaction(networkIdentifier, chainIDToAliasMapping, rawIdx, avaxAssetID, tx)
+	require.NoError(err)
+	require.Equal(AtomicAvaxAmount(big.NewInt(280750)), metadata[MetadataTxFee])
+
+	require.Equal([]*types.Operation{
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: 0,
 			},
-		}, ops)
-
-		assert.Equal(t, []*types.Operation{
-			{
-				OperationIdentifier: &types.OperationIdentifier{
-					Index: 1,
-				},
-				Type:   OpExport,
-				Status: types.String(StatusSuccess),
-				Account: &types.AccountIdentifier{
-					Address: "P-fuji1eql2fhqet2f8tg6funmpdja5tc374vhmdj2xz2",
-				},
-				Amount: &types.Amount{
-					Value:    "1000000",
-					Currency: AtomicAvaxCurrency,
-				},
-				CoinChange: &types.CoinChange{
-					CoinIdentifier: &types.CoinIdentifier{
-						Identifier: "7QUPqUAMdny53bVptZ2DgxLLN4qZ5X7MnBPseUKYnoh5C5v47:0",
-					},
-					CoinAction: types.CoinCreated,
-				},
+			Type:   OpExport,
+			Status: types.String(StatusSuccess),
+			Account: &types.AccountIdentifier{
+				Address: "0x3158e80abD5A1e1aa716003C9Db096792C379621",
 			},
-		}, metadata[MetadataExportedOutputs])
-	})
+			Amount: &types.Amount{
+				Value:    "-1280750000000000",
+				Currency: AvaxCurrency,
+			},
+			Metadata: map[string]interface{}{
+				"tx":                "7QUPqUAMdny53bVptZ2DgxLLN4qZ5X7MnBPseUKYnoh5C5v47",
+				"blockchain_id":     "yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp",
+				"network_id":        uint32(5),
+				"destination_chain": "11111111111111111111111111111111LpoYY",
+				"meta":              *meta,
+				"asset_id":          "U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK",
+			},
+		},
+	}, ops)
+
+	require.Equal([]*types.Operation{
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: 1,
+			},
+			Type:   OpExport,
+			Status: types.String(StatusSuccess),
+			Account: &types.AccountIdentifier{
+				Address: "P-fuji1eql2fhqet2f8tg6funmpdja5tc374vhmdj2xz2",
+			},
+			Amount: &types.Amount{
+				Value:    "1000000",
+				Currency: AtomicAvaxCurrency,
+			},
+			CoinChange: &types.CoinChange{
+				CoinIdentifier: &types.CoinIdentifier{
+					Identifier: "7QUPqUAMdny53bVptZ2DgxLLN4qZ5X7MnBPseUKYnoh5C5v47:0",
+				},
+				CoinAction: types.CoinCreated,
+			},
+		},
+	}, metadata[MetadataExportedOutputs])
 }

--- a/mapper/types.go
+++ b/mapper/types.go
@@ -1,9 +1,8 @@
 package mapper
 
 import (
-	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 const (

--- a/mapper/types_test.go
+++ b/mapper/types_test.go
@@ -18,8 +18,6 @@ var USDC = &types.Currency{
 }
 
 func TestMixedCaseAddress(t *testing.T) {
-	require := require.New(t)
-
 	parsedCurrency := ToCurrency("USDC", 6, common.HexToAddress("0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"))
-	require.True(utils.Equal(USDC, parsedCurrency))
+	require.True(t, utils.Equal(USDC, parsedCurrency))
 }

--- a/service/backend/cchainatomictx/account_test.go
+++ b/service/backend/cchainatomictx/account_test.go
@@ -71,13 +71,13 @@ func TestAccountBalance(t *testing.T) {
 			GetAtomicUTXOs(gomock.Any(), []ids.ShortID{addr}, constants.XChain.String(), backend.getUTXOsPageSize, ids.ShortEmpty, ids.Empty).
 			Return(nil, ids.ShortEmpty, ids.Empty, nil)
 
-		resp, apiErr := backend.AccountBalance(context.Background(), &types.AccountBalanceRequest{
+		resp, terr := backend.AccountBalance(context.Background(), &types.AccountBalanceRequest{
 			NetworkIdentifier: &types.NetworkIdentifier{},
 			AccountIdentifier: &types.AccountIdentifier{
 				Address: accountAddress,
 			},
 		})
-		require.Nil(apiErr)
+		require.Nil(terr)
 
 		require.Len(resp.Balances, 1)
 		require.Equal(mapper.AtomicAvaxCurrency, resp.Balances[0].Currency)
@@ -120,13 +120,13 @@ func TestAccountCoins(t *testing.T) {
 			GetAtomicUTXOs(gomock.Any(), []ids.ShortID{addr}, constants.XChain.String(), backend.getUTXOsPageSize, ids.ShortEmpty, ids.Empty).
 			Return(nil, ids.ShortEmpty, ids.Empty, nil)
 
-		resp, apiErr := backend.AccountCoins(context.Background(), &types.AccountCoinsRequest{
+		resp, terr := backend.AccountCoins(context.Background(), &types.AccountCoinsRequest{
 			NetworkIdentifier: &types.NetworkIdentifier{},
 			AccountIdentifier: &types.AccountIdentifier{
 				Address: accountAddress,
 			},
 		})
-		require.Nil(apiErr)
+		require.Nil(terr)
 
 		require.Len(resp.Coins, 3)
 

--- a/service/backend/cchainatomictx/account_test.go
+++ b/service/backend/cchainatomictx/account_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	ethtypes "github.com/ava-labs/coreth/core/types"
 	"github.com/coinbase/rosetta-sdk-go/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanche-rosetta/client"
@@ -50,9 +50,9 @@ func TestAccountBalance(t *testing.T) {
 	backend := NewBackend(evmMock, ids.Empty, avalancheNetworkID)
 	accountAddress := "C-fuji15f9g0h5xkr5cp47n6u3qxj6yjtzzzrdr23a3tl"
 	_, _, addressBytes, err := address.Parse(accountAddress)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	addr, err := ids.ToShortID(addressBytes)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	t.Run("C-chain atomic tx balance is sum of UTXOs", func(t *testing.T) {
 		utxo0Bytes := makeUtxoBytes(t, backend, utxos[0].id, utxos[0].amount)
@@ -75,11 +75,11 @@ func TestAccountBalance(t *testing.T) {
 				Address: accountAddress,
 			},
 		})
-		assert.Nil(t, apiErr)
+		require.Nil(t, apiErr)
 
-		assert.Equal(t, 1, len(resp.Balances))
-		assert.Equal(t, mapper.AtomicAvaxCurrency, resp.Balances[0].Currency)
-		assert.Equal(t, "2500000", resp.Balances[0].Value)
+		require.Equal(t, 1, len(resp.Balances))
+		require.Equal(t, mapper.AtomicAvaxCurrency, resp.Balances[0].Currency)
+		require.Equal(t, "2500000", resp.Balances[0].Value)
 	})
 }
 
@@ -91,9 +91,9 @@ func TestAccountCoins(t *testing.T) {
 	backend.getUTXOsPageSize = 2
 	accountAddress := "C-fuji15f9g0h5xkr5cp47n6u3qxj6yjtzzzrdr23a3tl"
 	_, _, addressBytes, err := address.Parse(accountAddress)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	addr, err := ids.ToShortID(addressBytes)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	t.Run("C-chain atomic tx coins returns UTXOs", func(t *testing.T) {
 		utxo0Bytes := makeUtxoBytes(t, backend, utxos[0].id, utxos[0].amount)
@@ -122,21 +122,21 @@ func TestAccountCoins(t *testing.T) {
 				Address: accountAddress,
 			},
 		})
-		assert.Nil(t, apiErr)
+		require.Nil(t, apiErr)
 
-		assert.Equal(t, 3, len(resp.Coins))
+		require.Equal(t, 3, len(resp.Coins))
 
-		assert.Equal(t, utxos[0].id, resp.Coins[0].CoinIdentifier.Identifier)
-		assert.Equal(t, mapper.AtomicAvaxCurrency, resp.Coins[0].Amount.Currency)
-		assert.Equal(t, strconv.FormatUint(utxos[0].amount, 10), resp.Coins[0].Amount.Value)
+		require.Equal(t, utxos[0].id, resp.Coins[0].CoinIdentifier.Identifier)
+		require.Equal(t, mapper.AtomicAvaxCurrency, resp.Coins[0].Amount.Currency)
+		require.Equal(t, strconv.FormatUint(utxos[0].amount, 10), resp.Coins[0].Amount.Value)
 
-		assert.Equal(t, utxos[3].id, resp.Coins[1].CoinIdentifier.Identifier)
-		assert.Equal(t, mapper.AtomicAvaxCurrency, resp.Coins[1].Amount.Currency)
-		assert.Equal(t, strconv.FormatUint(utxos[3].amount, 10), resp.Coins[1].Amount.Value)
+		require.Equal(t, utxos[3].id, resp.Coins[1].CoinIdentifier.Identifier)
+		require.Equal(t, mapper.AtomicAvaxCurrency, resp.Coins[1].Amount.Currency)
+		require.Equal(t, strconv.FormatUint(utxos[3].amount, 10), resp.Coins[1].Amount.Value)
 
-		assert.Equal(t, utxos[1].id, resp.Coins[2].CoinIdentifier.Identifier)
-		assert.Equal(t, mapper.AtomicAvaxCurrency, resp.Coins[2].Amount.Currency)
-		assert.Equal(t, strconv.FormatUint(utxos[1].amount, 10), resp.Coins[2].Amount.Value)
+		require.Equal(t, utxos[1].id, resp.Coins[2].CoinIdentifier.Identifier)
+		require.Equal(t, mapper.AtomicAvaxCurrency, resp.Coins[2].Amount.Currency)
+		require.Equal(t, strconv.FormatUint(utxos[1].amount, 10), resp.Coins[2].Amount.Value)
 	})
 }
 

--- a/service/backend/cchainatomictx/account_test.go
+++ b/service/backend/cchainatomictx/account_test.go
@@ -55,6 +55,8 @@ func TestAccountBalance(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("C-chain atomic tx balance is sum of UTXOs", func(t *testing.T) {
+		require := require.New(t)
+
 		utxo0Bytes := makeUtxoBytes(t, backend, utxos[0].id, utxos[0].amount)
 		utxo1Bytes := makeUtxoBytes(t, backend, utxos[1].id, utxos[1].amount)
 
@@ -75,11 +77,11 @@ func TestAccountBalance(t *testing.T) {
 				Address: accountAddress,
 			},
 		})
-		require.Nil(t, apiErr)
+		require.Nil(apiErr)
 
-		require.Equal(t, 1, len(resp.Balances))
-		require.Equal(t, mapper.AtomicAvaxCurrency, resp.Balances[0].Currency)
-		require.Equal(t, "2500000", resp.Balances[0].Value)
+		require.Len(resp.Balances, 1)
+		require.Equal(mapper.AtomicAvaxCurrency, resp.Balances[0].Currency)
+		require.Equal("2500000", resp.Balances[0].Value)
 	})
 }
 
@@ -96,6 +98,8 @@ func TestAccountCoins(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("C-chain atomic tx coins returns UTXOs", func(t *testing.T) {
+		require := require.New(t)
+
 		utxo0Bytes := makeUtxoBytes(t, backend, utxos[0].id, utxos[0].amount)
 		utxo1Bytes := makeUtxoBytes(t, backend, utxos[1].id, utxos[1].amount)
 		utxo2Bytes := makeUtxoBytes(t, backend, utxos[2].id, utxos[2].amount)
@@ -122,21 +126,21 @@ func TestAccountCoins(t *testing.T) {
 				Address: accountAddress,
 			},
 		})
-		require.Nil(t, apiErr)
+		require.Nil(apiErr)
 
-		require.Equal(t, 3, len(resp.Coins))
+		require.Len(resp.Coins, 3)
 
-		require.Equal(t, utxos[0].id, resp.Coins[0].CoinIdentifier.Identifier)
-		require.Equal(t, mapper.AtomicAvaxCurrency, resp.Coins[0].Amount.Currency)
-		require.Equal(t, strconv.FormatUint(utxos[0].amount, 10), resp.Coins[0].Amount.Value)
+		require.Equal(utxos[0].id, resp.Coins[0].CoinIdentifier.Identifier)
+		require.Equal(mapper.AtomicAvaxCurrency, resp.Coins[0].Amount.Currency)
+		require.Equal(strconv.FormatUint(utxos[0].amount, 10), resp.Coins[0].Amount.Value)
 
-		require.Equal(t, utxos[3].id, resp.Coins[1].CoinIdentifier.Identifier)
-		require.Equal(t, mapper.AtomicAvaxCurrency, resp.Coins[1].Amount.Currency)
-		require.Equal(t, strconv.FormatUint(utxos[3].amount, 10), resp.Coins[1].Amount.Value)
+		require.Equal(utxos[3].id, resp.Coins[1].CoinIdentifier.Identifier)
+		require.Equal(mapper.AtomicAvaxCurrency, resp.Coins[1].Amount.Currency)
+		require.Equal(strconv.FormatUint(utxos[3].amount, 10), resp.Coins[1].Amount.Value)
 
-		require.Equal(t, utxos[1].id, resp.Coins[2].CoinIdentifier.Identifier)
-		require.Equal(t, mapper.AtomicAvaxCurrency, resp.Coins[2].Amount.Currency)
-		require.Equal(t, strconv.FormatUint(utxos[1].amount, 10), resp.Coins[2].Amount.Value)
+		require.Equal(utxos[1].id, resp.Coins[2].CoinIdentifier.Identifier)
+		require.Equal(mapper.AtomicAvaxCurrency, resp.Coins[2].Amount.Currency)
+		require.Equal(strconv.FormatUint(utxos[1].amount, 10), resp.Coins[2].Amount.Value)
 	})
 }
 

--- a/service/backend/cchainatomictx/account_test.go
+++ b/service/backend/cchainatomictx/account_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
-	ethtypes "github.com/ava-labs/coreth/core/types"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -18,6 +17,8 @@ import (
 	"github.com/ava-labs/avalanche-rosetta/client"
 	"github.com/ava-labs/avalanche-rosetta/constants"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
+
+	ethtypes "github.com/ava-labs/coreth/core/types"
 )
 
 type utxo struct {

--- a/service/backend/cchainatomictx/backend.go
+++ b/service/backend/cchainatomictx/backend.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/ava-labs/avalanche-rosetta/client"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
-	cmapper "github.com/ava-labs/avalanche-rosetta/mapper/cchainatomictx"
 	"github.com/ava-labs/avalanche-rosetta/service"
+
+	cmapper "github.com/ava-labs/avalanche-rosetta/mapper/cchainatomictx"
 )
 
 var (

--- a/service/backend/cchainatomictx/backend_test.go
+++ b/service/backend/cchainatomictx/backend_test.go
@@ -40,101 +40,105 @@ func TestShouldHandleRequest(t *testing.T) {
 	nonAtomicTxString := "evmtxstring"
 
 	t.Run("return true for c-chain atomic tx requests", func(t *testing.T) {
-		require.True(t, backend.ShouldHandleRequest(&types.AccountBalanceRequest{
+		require := require.New(t)
+
+		require.True(backend.ShouldHandleRequest(&types.AccountBalanceRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			AccountIdentifier: bech32AccountIdentifier,
 		}))
-		require.True(t, backend.ShouldHandleRequest(&types.AccountCoinsRequest{
+		require.True(backend.ShouldHandleRequest(&types.AccountCoinsRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			AccountIdentifier: bech32AccountIdentifier,
 		}))
-		require.True(t, backend.ShouldHandleRequest(&types.ConstructionDeriveRequest{
+		require.True(backend.ShouldHandleRequest(&types.ConstructionDeriveRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			Metadata: map[string]interface{}{
 				mapper.MetadataAddressFormat: mapper.AddressFormatBech32,
 			},
 		}))
-		require.True(t, backend.ShouldHandleRequest(&types.ConstructionMetadataRequest{
+		require.True(backend.ShouldHandleRequest(&types.ConstructionMetadataRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			Options: map[string]interface{}{
 				cmapper.MetadataAtomicTxGas: 123,
 			},
 		}))
-		require.True(t, backend.ShouldHandleRequest(&types.ConstructionPreprocessRequest{
+		require.True(backend.ShouldHandleRequest(&types.ConstructionPreprocessRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			Operations:        atomicOperations,
 		}))
-		require.True(t, backend.ShouldHandleRequest(&types.ConstructionPayloadsRequest{
+		require.True(backend.ShouldHandleRequest(&types.ConstructionPayloadsRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			Operations:        atomicOperations,
 		}))
-		require.True(t, backend.ShouldHandleRequest(&types.ConstructionParseRequest{
+		require.True(backend.ShouldHandleRequest(&types.ConstructionParseRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			Transaction:       atomicTxString,
 			Signed:            true,
 		}))
-		require.True(t, backend.ShouldHandleRequest(&types.ConstructionCombineRequest{
+		require.True(backend.ShouldHandleRequest(&types.ConstructionCombineRequest{
 			NetworkIdentifier:   cChainNetworkIdentifier,
 			UnsignedTransaction: atomicTxString,
 		}))
-		require.True(t, backend.ShouldHandleRequest(&types.ConstructionHashRequest{
+		require.True(backend.ShouldHandleRequest(&types.ConstructionHashRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			SignedTransaction: atomicTxString,
 		}))
-		require.True(t, backend.ShouldHandleRequest(&types.ConstructionSubmitRequest{
+		require.True(backend.ShouldHandleRequest(&types.ConstructionSubmitRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			SignedTransaction: atomicTxString,
 		}))
 	})
 
 	t.Run("return false for other c-chain requests", func(t *testing.T) {
-		require.False(t, backend.ShouldHandleRequest(&types.AccountBalanceRequest{
+		require := require.New(t)
+
+		require.False(backend.ShouldHandleRequest(&types.AccountBalanceRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			AccountIdentifier: evmAccountIdentifier,
 		}))
-		require.False(t, backend.ShouldHandleRequest(&types.AccountCoinsRequest{
+		require.False(backend.ShouldHandleRequest(&types.AccountCoinsRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			AccountIdentifier: evmAccountIdentifier,
 		}))
-		require.False(t, backend.ShouldHandleRequest(&types.ConstructionDeriveRequest{
+		require.False(backend.ShouldHandleRequest(&types.ConstructionDeriveRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 		}))
-		require.False(t, backend.ShouldHandleRequest(&types.ConstructionMetadataRequest{
+		require.False(backend.ShouldHandleRequest(&types.ConstructionMetadataRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 		}))
-		require.False(t, backend.ShouldHandleRequest(&types.ConstructionPreprocessRequest{
-			NetworkIdentifier: cChainNetworkIdentifier,
-			Operations:        evmOperations,
-		}))
-		require.False(t, backend.ShouldHandleRequest(&types.ConstructionPayloadsRequest{
+		require.False(backend.ShouldHandleRequest(&types.ConstructionPreprocessRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			Operations:        evmOperations,
 		}))
-		require.False(t, backend.ShouldHandleRequest(&types.ConstructionParseRequest{
+		require.False(backend.ShouldHandleRequest(&types.ConstructionPayloadsRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			Operations:        evmOperations,
+		}))
+		require.False(backend.ShouldHandleRequest(&types.ConstructionParseRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			Transaction:       nonAtomicTxString,
 		}))
-		require.False(t, backend.ShouldHandleRequest(&types.ConstructionCombineRequest{
+		require.False(backend.ShouldHandleRequest(&types.ConstructionCombineRequest{
 			NetworkIdentifier:   cChainNetworkIdentifier,
 			UnsignedTransaction: nonAtomicTxString,
 		}))
-		require.False(t, backend.ShouldHandleRequest(&types.ConstructionHashRequest{
+		require.False(backend.ShouldHandleRequest(&types.ConstructionHashRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			SignedTransaction: nonAtomicTxString,
 		}))
-		require.False(t, backend.ShouldHandleRequest(&types.ConstructionSubmitRequest{
+		require.False(backend.ShouldHandleRequest(&types.ConstructionSubmitRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			SignedTransaction: nonAtomicTxString,
 		}))
 
 		// Backend does not support /block and /network endpoints
-		require.False(t, backend.ShouldHandleRequest(&types.BlockRequest{
+		require.False(backend.ShouldHandleRequest(&types.BlockRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 		}))
-		require.False(t, backend.ShouldHandleRequest(&types.BlockTransactionRequest{
+		require.False(backend.ShouldHandleRequest(&types.BlockTransactionRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 		}))
-		require.False(t, backend.ShouldHandleRequest(&types.NetworkRequest{
+		require.False(backend.ShouldHandleRequest(&types.NetworkRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 		}))
 	})

--- a/service/backend/cchainatomictx/backend_test.go
+++ b/service/backend/cchainatomictx/backend_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ava-labs/coreth/plugin/evm"
 	"github.com/coinbase/rosetta-sdk-go/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanche-rosetta/constants"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
@@ -40,101 +40,101 @@ func TestShouldHandleRequest(t *testing.T) {
 	nonAtomicTxString := "evmtxstring"
 
 	t.Run("return true for c-chain atomic tx requests", func(t *testing.T) {
-		assert.True(t, backend.ShouldHandleRequest(&types.AccountBalanceRequest{
+		require.True(t, backend.ShouldHandleRequest(&types.AccountBalanceRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			AccountIdentifier: bech32AccountIdentifier,
 		}))
-		assert.True(t, backend.ShouldHandleRequest(&types.AccountCoinsRequest{
+		require.True(t, backend.ShouldHandleRequest(&types.AccountCoinsRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			AccountIdentifier: bech32AccountIdentifier,
 		}))
-		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionDeriveRequest{
+		require.True(t, backend.ShouldHandleRequest(&types.ConstructionDeriveRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			Metadata: map[string]interface{}{
 				mapper.MetadataAddressFormat: mapper.AddressFormatBech32,
 			},
 		}))
-		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionMetadataRequest{
+		require.True(t, backend.ShouldHandleRequest(&types.ConstructionMetadataRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			Options: map[string]interface{}{
 				cmapper.MetadataAtomicTxGas: 123,
 			},
 		}))
-		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionPreprocessRequest{
+		require.True(t, backend.ShouldHandleRequest(&types.ConstructionPreprocessRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			Operations:        atomicOperations,
 		}))
-		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionPayloadsRequest{
+		require.True(t, backend.ShouldHandleRequest(&types.ConstructionPayloadsRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			Operations:        atomicOperations,
 		}))
-		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionParseRequest{
+		require.True(t, backend.ShouldHandleRequest(&types.ConstructionParseRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			Transaction:       atomicTxString,
 			Signed:            true,
 		}))
-		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionCombineRequest{
+		require.True(t, backend.ShouldHandleRequest(&types.ConstructionCombineRequest{
 			NetworkIdentifier:   cChainNetworkIdentifier,
 			UnsignedTransaction: atomicTxString,
 		}))
-		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionHashRequest{
+		require.True(t, backend.ShouldHandleRequest(&types.ConstructionHashRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			SignedTransaction: atomicTxString,
 		}))
-		assert.True(t, backend.ShouldHandleRequest(&types.ConstructionSubmitRequest{
+		require.True(t, backend.ShouldHandleRequest(&types.ConstructionSubmitRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			SignedTransaction: atomicTxString,
 		}))
 	})
 
 	t.Run("return false for other c-chain requests", func(t *testing.T) {
-		assert.False(t, backend.ShouldHandleRequest(&types.AccountBalanceRequest{
+		require.False(t, backend.ShouldHandleRequest(&types.AccountBalanceRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			AccountIdentifier: evmAccountIdentifier,
 		}))
-		assert.False(t, backend.ShouldHandleRequest(&types.AccountCoinsRequest{
+		require.False(t, backend.ShouldHandleRequest(&types.AccountCoinsRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			AccountIdentifier: evmAccountIdentifier,
 		}))
-		assert.False(t, backend.ShouldHandleRequest(&types.ConstructionDeriveRequest{
+		require.False(t, backend.ShouldHandleRequest(&types.ConstructionDeriveRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 		}))
-		assert.False(t, backend.ShouldHandleRequest(&types.ConstructionMetadataRequest{
+		require.False(t, backend.ShouldHandleRequest(&types.ConstructionMetadataRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 		}))
-		assert.False(t, backend.ShouldHandleRequest(&types.ConstructionPreprocessRequest{
-			NetworkIdentifier: cChainNetworkIdentifier,
-			Operations:        evmOperations,
-		}))
-		assert.False(t, backend.ShouldHandleRequest(&types.ConstructionPayloadsRequest{
+		require.False(t, backend.ShouldHandleRequest(&types.ConstructionPreprocessRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			Operations:        evmOperations,
 		}))
-		assert.False(t, backend.ShouldHandleRequest(&types.ConstructionParseRequest{
+		require.False(t, backend.ShouldHandleRequest(&types.ConstructionPayloadsRequest{
+			NetworkIdentifier: cChainNetworkIdentifier,
+			Operations:        evmOperations,
+		}))
+		require.False(t, backend.ShouldHandleRequest(&types.ConstructionParseRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			Transaction:       nonAtomicTxString,
 		}))
-		assert.False(t, backend.ShouldHandleRequest(&types.ConstructionCombineRequest{
+		require.False(t, backend.ShouldHandleRequest(&types.ConstructionCombineRequest{
 			NetworkIdentifier:   cChainNetworkIdentifier,
 			UnsignedTransaction: nonAtomicTxString,
 		}))
-		assert.False(t, backend.ShouldHandleRequest(&types.ConstructionHashRequest{
+		require.False(t, backend.ShouldHandleRequest(&types.ConstructionHashRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			SignedTransaction: nonAtomicTxString,
 		}))
-		assert.False(t, backend.ShouldHandleRequest(&types.ConstructionSubmitRequest{
+		require.False(t, backend.ShouldHandleRequest(&types.ConstructionSubmitRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 			SignedTransaction: nonAtomicTxString,
 		}))
 
 		// Backend does not support /block and /network endpoints
-		assert.False(t, backend.ShouldHandleRequest(&types.BlockRequest{
+		require.False(t, backend.ShouldHandleRequest(&types.BlockRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 		}))
-		assert.False(t, backend.ShouldHandleRequest(&types.BlockTransactionRequest{
+		require.False(t, backend.ShouldHandleRequest(&types.BlockTransactionRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 		}))
-		assert.False(t, backend.ShouldHandleRequest(&types.NetworkRequest{
+		require.False(t, backend.ShouldHandleRequest(&types.NetworkRequest{
 			NetworkIdentifier: cChainNetworkIdentifier,
 		}))
 	})

--- a/service/backend/cchainatomictx/backend_test.go
+++ b/service/backend/cchainatomictx/backend_test.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/ava-labs/avalanche-rosetta/constants"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
-	cmapper "github.com/ava-labs/avalanche-rosetta/mapper/cchainatomictx"
 	"github.com/ava-labs/avalanche-rosetta/service"
+
+	cmapper "github.com/ava-labs/avalanche-rosetta/mapper/cchainatomictx"
 )
 
 func TestShouldHandleRequest(t *testing.T) {

--- a/service/backend/cchainatomictx/construction.go
+++ b/service/backend/cchainatomictx/construction.go
@@ -13,13 +13,14 @@ import (
 	"github.com/ava-labs/coreth/plugin/evm"
 	"github.com/coinbase/rosetta-sdk-go/parser"
 	"github.com/coinbase/rosetta-sdk-go/types"
-	ethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/ava-labs/avalanche-rosetta/constants"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
-	cmapper "github.com/ava-labs/avalanche-rosetta/mapper/cchainatomictx"
 	"github.com/ava-labs/avalanche-rosetta/service"
 	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
+
+	cmapper "github.com/ava-labs/avalanche-rosetta/mapper/cchainatomictx"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 var (

--- a/service/backend/cchainatomictx/construction.go
+++ b/service/backend/cchainatomictx/construction.go
@@ -28,7 +28,7 @@ var (
 )
 
 // ConstructionDerive implements /construction/derive endpoint for C-chain atomic transactions
-func (b *Backend) ConstructionDerive(_ context.Context, req *types.ConstructionDeriveRequest) (*types.ConstructionDeriveResponse, *types.Error) {
+func (*Backend) ConstructionDerive(_ context.Context, req *types.ConstructionDeriveRequest) (*types.ConstructionDeriveResponse, *types.Error) {
 	return common.DeriveBech32Address(constants.CChain, req)
 }
 
@@ -264,7 +264,7 @@ func (b *Backend) ConstructionCombine(_ context.Context, req *types.Construction
 }
 
 // CombineTx implements C-chain atomic transaction specific logic for combining unsigned transactions and signatures
-func (b *Backend) CombineTx(tx common.AvaxTx, signatures []*types.Signature) (common.AvaxTx, *types.Error) {
+func (*Backend) CombineTx(tx common.AvaxTx, signatures []*types.Signature) (common.AvaxTx, *types.Error) {
 	cTx, ok := tx.(*cAtomicTx)
 	if !ok {
 		return nil, service.WrapError(service.ErrInvalidInput, "invalid transaction")

--- a/service/backend/cchainatomictx/construction_test.go
+++ b/service/backend/cchainatomictx/construction_test.go
@@ -165,9 +165,9 @@ func TestExportTxConstruction(t *testing.T) {
 			Operations:        exportOperations,
 		}
 
-		resp, apiErr := backend.ConstructionPreprocess(ctx, req)
+		resp, terr := backend.ConstructionPreprocess(ctx, req)
 
-		require.Nil(t, apiErr)
+		require.Nil(t, terr)
 		require.Equal(t, metadataOptions, resp.Options)
 	})
 
@@ -184,9 +184,9 @@ func TestExportTxConstruction(t *testing.T) {
 			Return(nonce, nil)
 		clientMock.EXPECT().EstimateBaseFee(ctx).Return(big.NewInt(25_000_000_000), nil)
 
-		resp, apiErr := backend.ConstructionMetadata(ctx, req)
+		resp, terr := backend.ConstructionMetadata(ctx, req)
 
-		require.Nil(t, apiErr)
+		require.Nil(t, terr)
 		require.Equal(t, payloadsMetadata, resp.Metadata)
 		require.Equal(t, suggestedFeeValue, resp.SuggestedFee[0].Value)
 	})
@@ -198,9 +198,9 @@ func TestExportTxConstruction(t *testing.T) {
 			Operations:        exportOperations,
 		}
 
-		resp, apiErr := backend.ConstructionPayloads(ctx, req)
+		resp, terr := backend.ConstructionPayloads(ctx, req)
 
-		require.Nil(t, apiErr)
+		require.Nil(t, terr)
 		require.Equal(t, wrappedUnsignedExportTx, resp.UnsignedTransaction)
 		require.Equal(t, signingPayloads, resp.Payloads)
 	})
@@ -212,9 +212,9 @@ func TestExportTxConstruction(t *testing.T) {
 			Signed:            false,
 		}
 
-		resp, apiErr := backend.ConstructionParse(ctx, req)
+		resp, terr := backend.ConstructionParse(ctx, req)
 
-		require.Nil(t, apiErr)
+		require.Nil(t, terr)
 		require.Nil(t, resp.AccountIdentifierSigners)
 		require.Equal(t, exportOperations, resp.Operations)
 	})
@@ -226,9 +226,9 @@ func TestExportTxConstruction(t *testing.T) {
 			Signatures:          signatures,
 		}
 
-		resp, apiErr := backend.ConstructionCombine(ctx, req)
+		resp, terr := backend.ConstructionCombine(ctx, req)
 
-		require.Nil(t, apiErr)
+		require.Nil(t, terr)
 		require.Equal(t, wrappedSignedExportTx, resp.SignedTransaction)
 	})
 
@@ -239,9 +239,9 @@ func TestExportTxConstruction(t *testing.T) {
 			Signed:            true,
 		}
 
-		resp, apiErr := backend.ConstructionParse(ctx, req)
+		resp, terr := backend.ConstructionParse(ctx, req)
 
-		require.Nil(t, apiErr)
+		require.Nil(t, terr)
 		require.Equal(t, signers, resp.AccountIdentifierSigners)
 		require.Equal(t, exportOperations, resp.Operations)
 	})
@@ -256,18 +256,22 @@ func TestExportTxConstruction(t *testing.T) {
 	})
 
 	t.Run("submit endpoint", func(t *testing.T) {
-		signedTxBytes, _ := formatting.Decode(formatting.Hex, signedExportTx)
-		txID, _ := ids.FromString(signedExportTxHash)
+		require := require.New(t)
+
+		signedTxBytes, err := formatting.Decode(formatting.Hex, signedExportTx)
+		require.NoError(err)
+		txID, err := ids.FromString(signedExportTxHash)
+		require.NoError(err)
 
 		clientMock.EXPECT().IssueTx(ctx, signedTxBytes).Return(txID, nil)
 
-		resp, apiErr := backend.ConstructionSubmit(ctx, &types.ConstructionSubmitRequest{
+		resp, terr := backend.ConstructionSubmit(ctx, &types.ConstructionSubmitRequest{
 			NetworkIdentifier: networkIdentifier,
 			SignedTransaction: wrappedSignedExportTx,
 		})
 
-		require.Nil(t, apiErr)
-		require.Equal(t, signedExportTxHash, resp.TransactionIdentifier.Hash)
+		require.Nil(terr)
+		require.Equal(signedExportTxHash, resp.TransactionIdentifier.Hash)
 	})
 }
 
@@ -381,9 +385,9 @@ func TestImportTxConstruction(t *testing.T) {
 			Metadata:          preprocessMetadata,
 		}
 
-		resp, apiErr := backend.ConstructionPreprocess(ctx, req)
+		resp, terr := backend.ConstructionPreprocess(ctx, req)
 
-		require.Nil(t, apiErr)
+		require.Nil(t, terr)
 		require.Equal(t, metadataOptions, resp.Options)
 	})
 
@@ -397,9 +401,9 @@ func TestImportTxConstruction(t *testing.T) {
 		clientMock.EXPECT().GetBlockchainID(ctx, constants.PChain.String()).Return(pChainID, nil)
 		clientMock.EXPECT().EstimateBaseFee(ctx).Return(big.NewInt(25_000_000_000), nil)
 
-		resp, apiErr := backend.ConstructionMetadata(ctx, req)
+		resp, terr := backend.ConstructionMetadata(ctx, req)
 
-		require.Nil(t, apiErr)
+		require.Nil(t, terr)
 		require.Equal(t, payloadsMetadata, resp.Metadata)
 		require.Equal(t, suggestedFeeValue, resp.SuggestedFee[0].Value)
 	})
@@ -411,9 +415,9 @@ func TestImportTxConstruction(t *testing.T) {
 			Operations:        importOperations,
 		}
 
-		resp, apiErr := backend.ConstructionPayloads(ctx, req)
+		resp, terr := backend.ConstructionPayloads(ctx, req)
 
-		require.Nil(t, apiErr)
+		require.Nil(t, terr)
 		require.Equal(t, wrappedUnsignedImportTx, resp.UnsignedTransaction)
 		require.Equal(t, signingPayloads, resp.Payloads)
 	})
@@ -425,9 +429,9 @@ func TestImportTxConstruction(t *testing.T) {
 			Signed:            false,
 		}
 
-		resp, apiErr := backend.ConstructionParse(ctx, req)
+		resp, terr := backend.ConstructionParse(ctx, req)
 
-		require.Nil(t, apiErr)
+		require.Nil(t, terr)
 		require.Nil(t, resp.AccountIdentifierSigners)
 		require.Equal(t, importOperations, resp.Operations)
 	})
@@ -439,9 +443,9 @@ func TestImportTxConstruction(t *testing.T) {
 			Signatures:          signatures,
 		}
 
-		resp, apiErr := backend.ConstructionCombine(ctx, req)
+		resp, terr := backend.ConstructionCombine(ctx, req)
 
-		require.Nil(t, apiErr)
+		require.Nil(t, terr)
 		require.Equal(t, wrappedSignedImportTx, resp.SignedTransaction)
 	})
 
@@ -452,9 +456,9 @@ func TestImportTxConstruction(t *testing.T) {
 			Signed:            true,
 		}
 
-		resp, apiErr := backend.ConstructionParse(ctx, req)
+		resp, terr := backend.ConstructionParse(ctx, req)
 
-		require.Nil(t, apiErr)
+		require.Nil(t, terr)
 		require.Equal(t, signers, resp.AccountIdentifierSigners)
 		require.Equal(t, importOperations, resp.Operations)
 	})
@@ -469,17 +473,21 @@ func TestImportTxConstruction(t *testing.T) {
 	})
 
 	t.Run("submit endpoint", func(t *testing.T) {
-		signedTxBytes, _ := formatting.Decode(formatting.Hex, signedImportTx)
-		txID, _ := ids.FromString(signedImportTxHash)
+		require := require.New(t)
+
+		signedTxBytes, err := formatting.Decode(formatting.Hex, signedImportTx)
+		require.NoError(err)
+		txID, err := ids.FromString(signedImportTxHash)
+		require.NoError(err)
 
 		clientMock.EXPECT().IssueTx(ctx, signedTxBytes).Return(txID, nil)
 
-		resp, apiErr := backend.ConstructionSubmit(ctx, &types.ConstructionSubmitRequest{
+		resp, terr := backend.ConstructionSubmit(ctx, &types.ConstructionSubmitRequest{
 			NetworkIdentifier: networkIdentifier,
 			SignedTransaction: wrappedSignedImportTx,
 		})
 
-		require.Nil(t, apiErr)
-		require.Equal(t, signedImportTxHash, resp.TransactionIdentifier.Hash)
+		require.Nil(terr)
+		require.Equal(signedImportTxHash, resp.TransactionIdentifier.Hash)
 	})
 }

--- a/service/backend/cchainatomictx/construction_test.go
+++ b/service/backend/cchainatomictx/construction_test.go
@@ -9,10 +9,8 @@ import (
 	"testing"
 
 	"github.com/ava-labs/avalanchego/ids"
-	avaConst "github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/coinbase/rosetta-sdk-go/types"
-	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -21,6 +19,9 @@ import (
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 	"github.com/ava-labs/avalanche-rosetta/service"
 	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
+
+	avaconstants "github.com/ava-labs/avalanchego/utils/constants"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 var (
@@ -36,7 +37,7 @@ var (
 	cChainID, _ = ids.FromString("yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp")
 	pChainID    = ids.Empty
 
-	avalancheNetworkID = avaConst.FujiID
+	avalancheNetworkID = avaconstants.FujiID
 
 	avaxAssetID, _ = ids.FromString("U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK")
 )

--- a/service/backend/cchainatomictx/construction_test.go
+++ b/service/backend/cchainatomictx/construction_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	ethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanche-rosetta/client"
@@ -70,8 +70,8 @@ func TestConstructionDerive(t *testing.T) {
 				},
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(
+		require.Nil(t, err)
+		require.Equal(
 			t,
 			"C-fuji15f9g0h5xkr5cp47n6u3qxj6yjtzzzrdr23a3tl",
 			resp.AccountIdentifier.Address,
@@ -167,8 +167,8 @@ func TestExportTxConstruction(t *testing.T) {
 
 		resp, apiErr := backend.ConstructionPreprocess(ctx, req)
 
-		assert.Nil(t, apiErr)
-		assert.Equal(t, metadataOptions, resp.Options)
+		require.Nil(t, apiErr)
+		require.Equal(t, metadataOptions, resp.Options)
 	})
 
 	t.Run("metadata endpoint", func(t *testing.T) {
@@ -186,9 +186,9 @@ func TestExportTxConstruction(t *testing.T) {
 
 		resp, apiErr := backend.ConstructionMetadata(ctx, req)
 
-		assert.Nil(t, apiErr)
-		assert.Equal(t, payloadsMetadata, resp.Metadata)
-		assert.Equal(t, suggestedFeeValue, resp.SuggestedFee[0].Value)
+		require.Nil(t, apiErr)
+		require.Equal(t, payloadsMetadata, resp.Metadata)
+		require.Equal(t, suggestedFeeValue, resp.SuggestedFee[0].Value)
 	})
 
 	t.Run("payloads endpoint", func(t *testing.T) {
@@ -200,9 +200,9 @@ func TestExportTxConstruction(t *testing.T) {
 
 		resp, apiErr := backend.ConstructionPayloads(ctx, req)
 
-		assert.Nil(t, apiErr)
-		assert.Equal(t, wrappedUnsignedExportTx, resp.UnsignedTransaction)
-		assert.Equal(t, signingPayloads, resp.Payloads)
+		require.Nil(t, apiErr)
+		require.Equal(t, wrappedUnsignedExportTx, resp.UnsignedTransaction)
+		require.Equal(t, signingPayloads, resp.Payloads)
 	})
 
 	t.Run("parse endpoint (unsigned)", func(t *testing.T) {
@@ -214,9 +214,9 @@ func TestExportTxConstruction(t *testing.T) {
 
 		resp, apiErr := backend.ConstructionParse(ctx, req)
 
-		assert.Nil(t, apiErr)
-		assert.Nil(t, resp.AccountIdentifierSigners)
-		assert.Equal(t, exportOperations, resp.Operations)
+		require.Nil(t, apiErr)
+		require.Nil(t, resp.AccountIdentifierSigners)
+		require.Equal(t, exportOperations, resp.Operations)
 	})
 
 	t.Run("combine endpoint", func(t *testing.T) {
@@ -228,8 +228,8 @@ func TestExportTxConstruction(t *testing.T) {
 
 		resp, apiErr := backend.ConstructionCombine(ctx, req)
 
-		assert.Nil(t, apiErr)
-		assert.Equal(t, wrappedSignedExportTx, resp.SignedTransaction)
+		require.Nil(t, apiErr)
+		require.Equal(t, wrappedSignedExportTx, resp.SignedTransaction)
 	})
 
 	t.Run("parse (signed) endpoint", func(t *testing.T) {
@@ -241,9 +241,9 @@ func TestExportTxConstruction(t *testing.T) {
 
 		resp, apiErr := backend.ConstructionParse(ctx, req)
 
-		assert.Nil(t, apiErr)
-		assert.Equal(t, signers, resp.AccountIdentifierSigners)
-		assert.Equal(t, exportOperations, resp.Operations)
+		require.Nil(t, apiErr)
+		require.Equal(t, signers, resp.AccountIdentifierSigners)
+		require.Equal(t, exportOperations, resp.Operations)
 	})
 
 	t.Run("hash endpoint", func(t *testing.T) {
@@ -251,8 +251,8 @@ func TestExportTxConstruction(t *testing.T) {
 			NetworkIdentifier: networkIdentifier,
 			SignedTransaction: wrappedSignedExportTx,
 		})
-		assert.Nil(t, err)
-		assert.Equal(t, signedExportTxHash, resp.TransactionIdentifier.Hash)
+		require.Nil(t, err)
+		require.Equal(t, signedExportTxHash, resp.TransactionIdentifier.Hash)
 	})
 
 	t.Run("submit endpoint", func(t *testing.T) {
@@ -266,8 +266,8 @@ func TestExportTxConstruction(t *testing.T) {
 			SignedTransaction: wrappedSignedExportTx,
 		})
 
-		assert.Nil(t, apiErr)
-		assert.Equal(t, signedExportTxHash, resp.TransactionIdentifier.Hash)
+		require.Nil(t, apiErr)
+		require.Equal(t, signedExportTxHash, resp.TransactionIdentifier.Hash)
 	})
 }
 
@@ -383,8 +383,8 @@ func TestImportTxConstruction(t *testing.T) {
 
 		resp, apiErr := backend.ConstructionPreprocess(ctx, req)
 
-		assert.Nil(t, apiErr)
-		assert.Equal(t, metadataOptions, resp.Options)
+		require.Nil(t, apiErr)
+		require.Equal(t, metadataOptions, resp.Options)
 	})
 
 	t.Run("metadata endpoint", func(t *testing.T) {
@@ -399,9 +399,9 @@ func TestImportTxConstruction(t *testing.T) {
 
 		resp, apiErr := backend.ConstructionMetadata(ctx, req)
 
-		assert.Nil(t, apiErr)
-		assert.Equal(t, payloadsMetadata, resp.Metadata)
-		assert.Equal(t, suggestedFeeValue, resp.SuggestedFee[0].Value)
+		require.Nil(t, apiErr)
+		require.Equal(t, payloadsMetadata, resp.Metadata)
+		require.Equal(t, suggestedFeeValue, resp.SuggestedFee[0].Value)
 	})
 
 	t.Run("payloads endpoint", func(t *testing.T) {
@@ -413,9 +413,9 @@ func TestImportTxConstruction(t *testing.T) {
 
 		resp, apiErr := backend.ConstructionPayloads(ctx, req)
 
-		assert.Nil(t, apiErr)
-		assert.Equal(t, wrappedUnsignedImportTx, resp.UnsignedTransaction)
-		assert.Equal(t, signingPayloads, resp.Payloads)
+		require.Nil(t, apiErr)
+		require.Equal(t, wrappedUnsignedImportTx, resp.UnsignedTransaction)
+		require.Equal(t, signingPayloads, resp.Payloads)
 	})
 
 	t.Run("parse endpoint (unsigned)", func(t *testing.T) {
@@ -427,9 +427,9 @@ func TestImportTxConstruction(t *testing.T) {
 
 		resp, apiErr := backend.ConstructionParse(ctx, req)
 
-		assert.Nil(t, apiErr)
-		assert.Nil(t, resp.AccountIdentifierSigners)
-		assert.Equal(t, importOperations, resp.Operations)
+		require.Nil(t, apiErr)
+		require.Nil(t, resp.AccountIdentifierSigners)
+		require.Equal(t, importOperations, resp.Operations)
 	})
 
 	t.Run("combine endpoint", func(t *testing.T) {
@@ -441,8 +441,8 @@ func TestImportTxConstruction(t *testing.T) {
 
 		resp, apiErr := backend.ConstructionCombine(ctx, req)
 
-		assert.Nil(t, apiErr)
-		assert.Equal(t, wrappedSignedImportTx, resp.SignedTransaction)
+		require.Nil(t, apiErr)
+		require.Equal(t, wrappedSignedImportTx, resp.SignedTransaction)
 	})
 
 	t.Run("parse (signed) endpoint", func(t *testing.T) {
@@ -454,9 +454,9 @@ func TestImportTxConstruction(t *testing.T) {
 
 		resp, apiErr := backend.ConstructionParse(ctx, req)
 
-		assert.Nil(t, apiErr)
-		assert.Equal(t, signers, resp.AccountIdentifierSigners)
-		assert.Equal(t, importOperations, resp.Operations)
+		require.Nil(t, apiErr)
+		require.Equal(t, signers, resp.AccountIdentifierSigners)
+		require.Equal(t, importOperations, resp.Operations)
 	})
 
 	t.Run("hash endpoint", func(t *testing.T) {
@@ -464,8 +464,8 @@ func TestImportTxConstruction(t *testing.T) {
 			NetworkIdentifier: networkIdentifier,
 			SignedTransaction: wrappedSignedImportTx,
 		})
-		assert.Nil(t, err)
-		assert.Equal(t, signedImportTxHash, resp.TransactionIdentifier.Hash)
+		require.Nil(t, err)
+		require.Equal(t, signedImportTxHash, resp.TransactionIdentifier.Hash)
 	})
 
 	t.Run("submit endpoint", func(t *testing.T) {
@@ -479,7 +479,7 @@ func TestImportTxConstruction(t *testing.T) {
 			SignedTransaction: wrappedSignedImportTx,
 		})
 
-		assert.Nil(t, apiErr)
-		assert.Equal(t, signedImportTxHash, resp.TransactionIdentifier.Hash)
+		require.Nil(t, apiErr)
+		require.Equal(t, signedImportTxHash, resp.TransactionIdentifier.Hash)
 	})
 }

--- a/service/backend/cchainatomictx/types.go
+++ b/service/backend/cchainatomictx/types.go
@@ -10,9 +10,10 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/types"
 
 	"github.com/ava-labs/avalanche-rosetta/mapper"
-	cmapper "github.com/ava-labs/avalanche-rosetta/mapper/cchainatomictx"
 	"github.com/ava-labs/avalanche-rosetta/service"
 	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
+
+	cmapper "github.com/ava-labs/avalanche-rosetta/mapper/cchainatomictx"
 )
 
 var (

--- a/service/backend/common/construction.go
+++ b/service/backend/common/construction.go
@@ -17,8 +17,9 @@ import (
 
 	"github.com/ava-labs/avalanche-rosetta/constants"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
-	pmapper "github.com/ava-labs/avalanche-rosetta/mapper/pchain"
 	"github.com/ava-labs/avalanche-rosetta/service"
+
+	pmapper "github.com/ava-labs/avalanche-rosetta/mapper/pchain"
 )
 
 var (

--- a/service/backend/pchain/account.go
+++ b/service/backend/pchain/account.go
@@ -270,7 +270,7 @@ func (b *Backend) fetchBalance(ctx context.Context, addrString string, fetchImpo
 		return 0, nil, typedErr
 	}
 
-	balance, err := b.getBalancesWithoutMultisig(utxos)
+	balance, err := getBalancesWithoutMultisig(utxos)
 	if err != nil {
 		return 0, nil, service.WrapError(service.ErrInternalError, err)
 	}
@@ -290,7 +290,7 @@ func (b *Backend) fetchBalance(ctx context.Context, addrString string, fetchImpo
 // Copy of the platformvm service's GetBalance implementation.
 // This is needed as multisig UTXOs are cleaned in parseUTXOs and its output must be used for the calculations. Ref:
 // https://github.com/ava-labs/avalanchego/blob/0950acab667e0c16a55e9a9bb72bcbe25c3b88cf/vms/platformvm/service.go#L184
-func (*Backend) getBalancesWithoutMultisig(utxos []avax.UTXO) (*AccountBalance, error) {
+func getBalancesWithoutMultisig(utxos []avax.UTXO) (*AccountBalance, error) {
 	currentTime := uint64(time.Now().Unix())
 
 	accountBalance := &AccountBalance{

--- a/service/backend/pchain/account.go
+++ b/service/backend/pchain/account.go
@@ -9,23 +9,22 @@ import (
 	"strings"
 	"time"
 
-	avaConst "github.com/ava-labs/avalanchego/utils/constants"
-	"github.com/ava-labs/avalanchego/vms/platformvm/stakeable"
-	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
-
-	"github.com/ava-labs/avalanche-rosetta/constants"
-	pmapper "github.com/ava-labs/avalanche-rosetta/mapper/pchain"
-	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
 	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/stakeable"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/coinbase/rosetta-sdk-go/types"
 
+	"github.com/ava-labs/avalanche-rosetta/constants"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 	"github.com/ava-labs/avalanche-rosetta/service"
+	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
+
+	pmapper "github.com/ava-labs/avalanche-rosetta/mapper/pchain"
+	avaconstants "github.com/ava-labs/avalanchego/utils/constants"
 )
 
 var (
@@ -186,7 +185,7 @@ func (b *Backend) getPendingRewardsBalance(ctx context.Context, req *types.Accou
 	var nodeIDs []ids.NodeID
 	nodeIDs = append(nodeIDs, validatorNodeID)
 
-	validators, err := b.pClient.GetCurrentValidators(ctx, avaConst.PrimaryNetworkID, nodeIDs)
+	validators, err := b.pClient.GetCurrentValidators(ctx, avaconstants.PrimaryNetworkID, nodeIDs)
 	if err != nil {
 		return nil, service.WrapError(service.ErrInternalError, "unable to fetch validators")
 	}

--- a/service/backend/pchain/account.go
+++ b/service/backend/pchain/account.go
@@ -291,7 +291,7 @@ func (b *Backend) fetchBalance(ctx context.Context, addrString string, fetchImpo
 // Copy of the platformvm service's GetBalance implementation.
 // This is needed as multisig UTXOs are cleaned in parseUTXOs and its output must be used for the calculations. Ref:
 // https://github.com/ava-labs/avalanchego/blob/0950acab667e0c16a55e9a9bb72bcbe25c3b88cf/vms/platformvm/service.go#L184
-func (b *Backend) getBalancesWithoutMultisig(utxos []avax.UTXO) (*AccountBalance, error) {
+func (*Backend) getBalancesWithoutMultisig(utxos []avax.UTXO) (*AccountBalance, error) {
 	currentTime := uint64(time.Now().Unix())
 
 	accountBalance := &AccountBalance{

--- a/service/backend/pchain/account_test.go
+++ b/service/backend/pchain/account_test.go
@@ -17,9 +17,10 @@ import (
 	"github.com/ava-labs/avalanche-rosetta/client"
 	"github.com/ava-labs/avalanche-rosetta/constants"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
-	pmapper "github.com/ava-labs/avalanche-rosetta/mapper/pchain"
 	"github.com/ava-labs/avalanche-rosetta/service"
 	"github.com/ava-labs/avalanche-rosetta/service/backend/pchain/indexer"
+
+	pmapper "github.com/ava-labs/avalanche-rosetta/mapper/pchain"
 )
 
 type utxo struct {

--- a/service/backend/pchain/account_test.go
+++ b/service/backend/pchain/account_test.go
@@ -66,10 +66,14 @@ func TestAccountBalance(t *testing.T) {
 	backend.getUTXOsPageSize = 2
 
 	t.Run("Account Balance Test", func(t *testing.T) {
-		addr, _ := address.ParseToID(pChainAddr)
+		require := require.New(t)
+
+		addr, err := address.ParseToID(pChainAddr)
+		require.NoError(err)
 		utxo0Bytes := makeUtxoBytes(t, backend, utxos[0].id, utxos[0].amount)
 		utxo1Bytes := makeUtxoBytes(t, backend, utxos[1].id, utxos[1].amount)
-		utxo1Id, _ := ids.FromString(utxos[1].id)
+		utxo1ID, err := mapper.DecodeUTXOID(utxos[1].id)
+		require.NoError(err)
 		stakeUtxoBytes := makeStakeUtxoBytes(t, backend, utxos[1].amount)
 
 		// Mock on GetAssetDescription
@@ -81,12 +85,12 @@ func TestAccountBalance(t *testing.T) {
 		pageSize := uint32(2)
 		backend.getUTXOsPageSize = pageSize
 		pChainMock.EXPECT().GetAtomicUTXOs(ctx, []ids.ShortID{addr}, "", pageSize, ids.ShortEmpty, ids.Empty).
-			Return([][]byte{utxo0Bytes, utxo1Bytes}, addr, utxo1Id, nil)
-		pChainMock.EXPECT().GetAtomicUTXOs(ctx, []ids.ShortID{addr}, "", pageSize, addr, utxo1Id).
-			Return([][]byte{utxo1Bytes}, addr, utxo1Id, nil)
+			Return([][]byte{utxo0Bytes, utxo1Bytes}, addr, utxo1ID.InputID(), nil)
+		pChainMock.EXPECT().GetAtomicUTXOs(ctx, []ids.ShortID{addr}, "", pageSize, addr, utxo1ID.InputID()).
+			Return([][]byte{utxo1Bytes}, addr, utxo1ID.InputID(), nil)
 		pChainMock.EXPECT().GetStake(ctx, []ids.ShortID{addr}, false).Return(map[ids.ID]uint64{}, [][]byte{stakeUtxoBytes}, nil)
 
-		resp, err := backend.AccountBalance(
+		resp, terr := backend.AccountBalance(
 			ctx,
 			&types.AccountBalanceRequest{
 				NetworkIdentifier: &types.NetworkIdentifier{
@@ -104,37 +108,36 @@ func TestAccountBalance(t *testing.T) {
 			},
 		)
 
-		expected := &types.AccountBalanceResponse{
-			Balances: []*types.Amount{
-				{
-					Value:    "5000000000", // 1B + 2B from UTXOs, 1B from staked
-					Currency: mapper.AtomicAvaxCurrency,
-				},
+		require.Nil(terr)
+		require.Equal([]*types.Amount{
+			{
+				Value:    "5000000000", // 1B + 2B from UTXOs, 1B from staked
+				Currency: mapper.AtomicAvaxCurrency,
 			},
-		}
-
-		require.Nil(t, err)
-		require.Equal(t, expected.Balances, resp.Balances)
+		}, resp.Balances)
 	})
 
 	t.Run("Account Balance should return total of shared memory balance", func(t *testing.T) {
+		require := require.New(t)
+
 		// Mock on GetUTXOs
 		utxo0Bytes := makeUtxoBytes(t, backend, utxos[0].id, utxos[0].amount)
 		utxo1Bytes := makeUtxoBytes(t, backend, utxos[1].id, utxos[1].amount)
-		utxo1Id, _ := ids.FromString(utxos[1].id)
-		pChainAddrID, errp := address.ParseToID(pChainAddr)
-		require.Nil(t, errp)
+		utxo1ID, err := mapper.DecodeUTXOID(utxos[1].id)
+		require.NoError(err)
+		pChainAddrID, err := address.ParseToID(pChainAddr)
+		require.NoError(err)
 
 		// once before other calls, once after
 		pChainMock.EXPECT().GetHeight(ctx).Return(blockHeight, nil).Times(2)
 		pageSize := uint32(1024)
 		backend.getUTXOsPageSize = pageSize
 		pChainMock.EXPECT().GetAtomicUTXOs(ctx, []ids.ShortID{pChainAddrID}, constants.CChain.String(), pageSize, ids.ShortEmpty, ids.Empty).
-			Return([][]byte{utxo0Bytes, utxo1Bytes}, pChainAddrID, utxo1Id, nil)
+			Return([][]byte{utxo0Bytes, utxo1Bytes}, pChainAddrID, utxo1ID.InputID(), nil)
 		pChainMock.EXPECT().GetAtomicUTXOs(ctx, []ids.ShortID{pChainAddrID}, constants.XChain.String(), pageSize, ids.ShortEmpty, ids.Empty).
 			Return([][]byte{}, pChainAddrID, ids.Empty, nil)
 
-		resp, err := backend.AccountBalance(
+		resp, terr := backend.AccountBalance(
 			ctx,
 			&types.AccountBalanceRequest{
 				NetworkIdentifier: &types.NetworkIdentifier{
@@ -151,8 +154,8 @@ func TestAccountBalance(t *testing.T) {
 					mapper.AtomicAvaxCurrency,
 				},
 			})
-
-		expected := &types.AccountBalanceResponse{
+		require.Nil(terr)
+		require.Equal(&types.AccountBalanceResponse{
 			BlockIdentifier: &types.BlockIdentifier{
 				Index: int64(blockHeight),
 				Hash:  parsedBlock.BlockID.String(),
@@ -161,14 +164,13 @@ func TestAccountBalance(t *testing.T) {
 				Value:    "3000000000",
 				Currency: mapper.AtomicAvaxCurrency,
 			}},
-		}
-
-		require.Nil(t, err)
-		require.Equal(t, expected, resp)
+		}, resp)
 	})
 
 	t.Run("Account Balance should error if new block was added while fetching UTXOs", func(t *testing.T) {
-		addr, _ := address.ParseToID(pChainAddr)
+		require := require.New(t)
+		addr, err := address.ParseToID(pChainAddr)
+		require.NoError(err)
 
 		pageSize := uint32(2)
 		backend.getUTXOsPageSize = pageSize
@@ -179,7 +181,7 @@ func TestAccountBalance(t *testing.T) {
 		// return blockHeight + 1 to indicate a new block arrival
 		pChainMock.EXPECT().GetHeight(ctx).Return(blockHeight+1, nil)
 
-		resp, err := backend.AccountBalance(
+		resp, terr := backend.AccountBalance(
 			ctx,
 			&types.AccountBalanceRequest{
 				NetworkIdentifier: &types.NetworkIdentifier{
@@ -197,9 +199,9 @@ func TestAccountBalance(t *testing.T) {
 			},
 		)
 
-		require.Nil(t, resp)
-		require.Equal(t, "Internal server error", err.Message)
-		require.Equal(t, "new block added while fetching utxos", err.Details["error"])
+		require.Nil(resp)
+		require.Equal("Internal server error", terr.Message)
+		require.Equal("new block added while fetching utxos", terr.Details["error"])
 	})
 }
 
@@ -212,20 +214,24 @@ func TestAccountPendingRewardsBalance(t *testing.T) {
 	parserMock.EXPECT().GetGenesisBlock(ctx).Return(dummyGenesis, nil)
 	parserMock.EXPECT().ParseNonGenesisBlock(ctx, "", blockHeight).Return(parsedBlock, nil).AnyTimes()
 
-	validator1NodeID, _ := ids.NodeIDFromString("NodeID-Bvsx89JttQqhqdgwtizAPoVSNW74Xcr2S")
+	validator1NodeID, err := ids.NodeIDFromString("NodeID-Bvsx89JttQqhqdgwtizAPoVSNW74Xcr2S")
+	require.NoError(t, err)
 	validator1Reward := uint64(100000)
 	validator1AddressStr := "P-fuji1csj0hzu7rtljuhqnzp8m9shawlcefuvyl0m3e9"
-	validator1Address, _ := address.ParseToID(validator1AddressStr)
+	validator1Address, err := address.ParseToID(validator1AddressStr)
+	require.NoError(t, err)
 	validator1ValidationRewardOwner := &platformvm.ClientOwner{Addresses: []ids.ShortID{validator1Address}}
 
 	delegate1Reward := uint64(20000)
 	delegate1AddressStr := "P-fuji1raffss40pyr7hdhyp7p4hs6p049hjlc60xxwks"
-	delegate1Address, _ := address.ParseToID(delegate1AddressStr)
+	delegate1Address, err := address.ParseToID(delegate1AddressStr)
+	require.NoError(t, err)
 	delegate1RewardOwner := &platformvm.ClientOwner{Addresses: []ids.ShortID{delegate1Address}}
 
 	delegate2Reward := uint64(30000)
 	delegate2AddressStr := "P-fuji1tlt564kc8mqwr575lyg539r8h6xg7hfmgxnkcg"
-	delegate2Address, _ := address.ParseToID(delegate2AddressStr)
+	delegate2Address, err := address.ParseToID(delegate2AddressStr)
+	require.NoError(t, err)
 	delegate2RewardOwner := &platformvm.ClientOwner{Addresses: []ids.ShortID{delegate2Address}}
 
 	validators := []platformvm.ClientPermissionlessValidator{
@@ -364,15 +370,18 @@ func TestAccountCoins(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Account Coins Test regular coins", func(t *testing.T) {
+		require := require.New(t)
+
 		// Mock on GetAssetDescription
 		pChainMock.EXPECT().GetAssetDescription(ctx, mapper.AtomicAvaxCurrency.Symbol).Return(mockAssetDescription, nil)
 
 		// Mock on GetUTXOs
 		utxo0Bytes := makeUtxoBytes(t, backend, utxos[0].id, utxos[0].amount)
 		utxo1Bytes := makeUtxoBytes(t, backend, utxos[1].id, utxos[1].amount)
-		utxo1Id, _ := ids.FromString(utxos[1].id)
+		utxo1ID, err := mapper.DecodeUTXOID(utxos[1].id)
+		require.NoError(err)
 		pChainAddrID, errp := address.ParseToID(pChainAddr)
-		require.Nil(t, errp)
+		require.Nil(errp)
 
 		// once before other calls, once after
 		pChainMock.EXPECT().GetHeight(ctx).Return(blockHeight, nil).Times(2)
@@ -380,11 +389,11 @@ func TestAccountCoins(t *testing.T) {
 		pageSize := uint32(2)
 		backend.getUTXOsPageSize = pageSize
 		pChainMock.EXPECT().GetAtomicUTXOs(ctx, []ids.ShortID{pChainAddrID}, "", pageSize, ids.ShortEmpty, ids.Empty).
-			Return([][]byte{utxo0Bytes, utxo1Bytes}, pChainAddrID, utxo1Id, nil)
-		pChainMock.EXPECT().GetAtomicUTXOs(ctx, []ids.ShortID{pChainAddrID}, "", pageSize, pChainAddrID, utxo1Id).
-			Return([][]byte{utxo1Bytes}, pChainAddrID, utxo1Id, nil)
+			Return([][]byte{utxo0Bytes, utxo1Bytes}, pChainAddrID, utxo1ID.InputID(), nil)
+		pChainMock.EXPECT().GetAtomicUTXOs(ctx, []ids.ShortID{pChainAddrID}, "", pageSize, pChainAddrID, utxo1ID.InputID()).
+			Return([][]byte{utxo1Bytes}, pChainAddrID, utxo1ID.InputID(), nil)
 
-		resp, err := backend.AccountCoins(
+		resp, terr := backend.AccountCoins(
 			ctx,
 			&types.AccountCoinsRequest{
 				NetworkIdentifier: &types.NetworkIdentifier{
@@ -401,7 +410,8 @@ func TestAccountCoins(t *testing.T) {
 				},
 			})
 
-		expected := &types.AccountCoinsResponse{
+		require.Nil(terr)
+		require.Equal(&types.AccountCoinsResponse{
 			BlockIdentifier: &types.BlockIdentifier{
 				Index: int64(blockHeight),
 				Hash:  parsedBlock.BlockID.String(),
@@ -426,34 +436,34 @@ func TestAccountCoins(t *testing.T) {
 					},
 				},
 			},
-		}
-
-		require.Nil(t, err)
-		require.Equal(t, expected, resp)
+		}, resp)
 	})
 
 	t.Run("Account Coins Test shared memory coins", func(t *testing.T) {
+		require := require.New(t)
 		// Mock on GetAssetDescription
 		pChainMock.EXPECT().GetAssetDescription(ctx, mapper.AtomicAvaxCurrency.Symbol).Return(mockAssetDescription, nil)
 
 		// Mock on GetUTXOs
 		utxo0Bytes := makeUtxoBytes(t, backend, utxos[0].id, utxos[0].amount)
-		utxo0Id, _ := ids.FromString(utxos[0].id)
+		utxo0ID, err := mapper.DecodeUTXOID(utxos[0].id)
+		require.NoError(err)
 		utxo1Bytes := makeUtxoBytes(t, backend, utxos[1].id, utxos[1].amount)
-		utxo1Id, _ := ids.FromString(utxos[1].id)
-		pChainAddrID, errp := address.ParseToID(pChainAddr)
-		require.Nil(t, errp)
+		utxo1ID, err := mapper.DecodeUTXOID(utxos[1].id)
+		require.NoError(err)
+		pChainAddrID, err := address.ParseToID(pChainAddr)
+		require.NoError(err)
 
 		// once before other calls, once after
 		pChainMock.EXPECT().GetHeight(ctx).Return(blockHeight, nil).Times(2)
 		pageSize := uint32(1024)
 		backend.getUTXOsPageSize = pageSize
 		pChainMock.EXPECT().GetAtomicUTXOs(ctx, []ids.ShortID{pChainAddrID}, constants.CChain.String(), pageSize, ids.ShortEmpty, ids.Empty).
-			Return([][]byte{utxo0Bytes}, pChainAddrID, utxo0Id, nil)
+			Return([][]byte{utxo0Bytes}, pChainAddrID, utxo0ID.InputID(), nil)
 		pChainMock.EXPECT().GetAtomicUTXOs(ctx, []ids.ShortID{pChainAddrID}, constants.XChain.String(), pageSize, ids.ShortEmpty, ids.Empty).
-			Return([][]byte{utxo1Bytes}, pChainAddrID, utxo1Id, nil)
+			Return([][]byte{utxo1Bytes}, pChainAddrID, utxo1ID.InputID(), nil)
 
-		resp, err := backend.AccountCoins(
+		resp, terr := backend.AccountCoins(
 			ctx,
 			&types.AccountCoinsRequest{
 				NetworkIdentifier: &types.NetworkIdentifier{
@@ -498,8 +508,8 @@ func TestAccountCoins(t *testing.T) {
 			},
 		}
 
-		require.Nil(t, err)
-		require.Equal(t, expected, resp)
+		require.Nil(terr)
+		require.Equal(expected, resp)
 	})
 }
 

--- a/service/backend/pchain/account_test.go
+++ b/service/backend/pchain/account_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/coinbase/rosetta-sdk-go/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanche-rosetta/client"
@@ -62,7 +62,7 @@ func TestAccountBalance(t *testing.T) {
 		pChainNetworkIdentifier,
 		avalancheNetworkID,
 	)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	backend.getUTXOsPageSize = 2
 
 	t.Run("Account Balance Test", func(t *testing.T) {
@@ -113,8 +113,8 @@ func TestAccountBalance(t *testing.T) {
 			},
 		}
 
-		assert.Nil(t, err)
-		assert.Equal(t, expected.Balances, resp.Balances)
+		require.Nil(t, err)
+		require.Equal(t, expected.Balances, resp.Balances)
 	})
 
 	t.Run("Account Balance should return total of shared memory balance", func(t *testing.T) {
@@ -123,7 +123,7 @@ func TestAccountBalance(t *testing.T) {
 		utxo1Bytes := makeUtxoBytes(t, backend, utxos[1].id, utxos[1].amount)
 		utxo1Id, _ := ids.FromString(utxos[1].id)
 		pChainAddrID, errp := address.ParseToID(pChainAddr)
-		assert.Nil(t, errp)
+		require.Nil(t, errp)
 
 		// once before other calls, once after
 		pChainMock.EXPECT().GetHeight(ctx).Return(blockHeight, nil).Times(2)
@@ -163,8 +163,8 @@ func TestAccountBalance(t *testing.T) {
 			}},
 		}
 
-		assert.Nil(t, err)
-		assert.Equal(t, expected, resp)
+		require.Nil(t, err)
+		require.Equal(t, expected, resp)
 	})
 
 	t.Run("Account Balance should error if new block was added while fetching UTXOs", func(t *testing.T) {
@@ -197,9 +197,9 @@ func TestAccountBalance(t *testing.T) {
 			},
 		)
 
-		assert.Nil(t, resp)
-		assert.Equal(t, "Internal server error", err.Message)
-		assert.Equal(t, "new block added while fetching utxos", err.Details["error"])
+		require.Nil(t, resp)
+		require.Equal(t, "Internal server error", err.Message)
+		require.Equal(t, "new block added while fetching utxos", err.Details["error"])
 	})
 }
 
@@ -255,7 +255,7 @@ func TestAccountPendingRewardsBalance(t *testing.T) {
 		pChainNetworkIdentifier,
 		avalancheNetworkID,
 	)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	t.Run("Pending Rewards Validator By NodeID", func(t *testing.T) {
 		pChainMock.EXPECT().GetCurrentValidators(ctx, ids.Empty, []ids.NodeID{validator1NodeID}).Return(validators, nil)
@@ -297,8 +297,8 @@ func TestAccountPendingRewardsBalance(t *testing.T) {
 			},
 		}
 
-		assert.Nil(t, err)
-		assert.Equal(t, expected, resp)
+		require.Nil(t, err)
+		require.Equal(t, expected, resp)
 	})
 
 	t.Run("Pending Rewards Delegate by NodeID", func(t *testing.T) {
@@ -341,8 +341,8 @@ func TestAccountPendingRewardsBalance(t *testing.T) {
 			},
 		}
 
-		assert.Nil(t, err)
-		assert.Equal(t, expected, resp)
+		require.Nil(t, err)
+		require.Equal(t, expected, resp)
 	})
 }
 
@@ -361,7 +361,7 @@ func TestAccountCoins(t *testing.T) {
 		pChainNetworkIdentifier,
 		avalancheNetworkID,
 	)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	t.Run("Account Coins Test regular coins", func(t *testing.T) {
 		// Mock on GetAssetDescription
@@ -372,7 +372,7 @@ func TestAccountCoins(t *testing.T) {
 		utxo1Bytes := makeUtxoBytes(t, backend, utxos[1].id, utxos[1].amount)
 		utxo1Id, _ := ids.FromString(utxos[1].id)
 		pChainAddrID, errp := address.ParseToID(pChainAddr)
-		assert.Nil(t, errp)
+		require.Nil(t, errp)
 
 		// once before other calls, once after
 		pChainMock.EXPECT().GetHeight(ctx).Return(blockHeight, nil).Times(2)
@@ -428,8 +428,8 @@ func TestAccountCoins(t *testing.T) {
 			},
 		}
 
-		assert.Nil(t, err)
-		assert.Equal(t, expected, resp)
+		require.Nil(t, err)
+		require.Equal(t, expected, resp)
 	})
 
 	t.Run("Account Coins Test shared memory coins", func(t *testing.T) {
@@ -442,7 +442,7 @@ func TestAccountCoins(t *testing.T) {
 		utxo1Bytes := makeUtxoBytes(t, backend, utxos[1].id, utxos[1].amount)
 		utxo1Id, _ := ids.FromString(utxos[1].id)
 		pChainAddrID, errp := address.ParseToID(pChainAddr)
-		assert.Nil(t, errp)
+		require.Nil(t, errp)
 
 		// once before other calls, once after
 		pChainMock.EXPECT().GetHeight(ctx).Return(blockHeight, nil).Times(2)
@@ -498,8 +498,8 @@ func TestAccountCoins(t *testing.T) {
 			},
 		}
 
-		assert.Nil(t, err)
-		assert.Equal(t, expected, resp)
+		require.Nil(t, err)
+		require.Equal(t, expected, resp)
 	})
 }
 

--- a/service/backend/pchain/account_test.go
+++ b/service/backend/pchain/account_test.go
@@ -381,8 +381,8 @@ func TestAccountCoins(t *testing.T) {
 		utxo1Bytes := makeUtxoBytes(t, backend, utxos[1].id, utxos[1].amount)
 		utxo1ID, err := mapper.DecodeUTXOID(utxos[1].id)
 		require.NoError(err)
-		pChainAddrID, errp := address.ParseToID(pChainAddr)
-		require.Nil(errp)
+		pChainAddrID, err := address.ParseToID(pChainAddr)
+		require.NoError(err)
 
 		// once before other calls, once after
 		pChainMock.EXPECT().GetHeight(ctx).Return(blockHeight, nil).Times(2)

--- a/service/backend/pchain/backend.go
+++ b/service/backend/pchain/backend.go
@@ -115,7 +115,7 @@ func (b *Backend) ShouldHandleRequest(req interface{}) bool {
 }
 
 // isPChain checks network identifier to make sure sub-network identifier set to "P"
-func (b *Backend) isPChain(reqNetworkID *types.NetworkIdentifier) bool {
+func (*Backend) isPChain(reqNetworkID *types.NetworkIdentifier) bool {
 	return reqNetworkID != nil &&
 		reqNetworkID.SubNetworkIdentifier != nil &&
 		reqNetworkID.SubNetworkIdentifier.Network == constants.PChain.String()

--- a/service/backend/pchain/backend.go
+++ b/service/backend/pchain/backend.go
@@ -84,38 +84,38 @@ func NewBackend(
 func (b *Backend) ShouldHandleRequest(req interface{}) bool {
 	switch r := req.(type) {
 	case *types.AccountBalanceRequest:
-		return b.isPChain(r.NetworkIdentifier)
+		return isPChain(r.NetworkIdentifier)
 	case *types.AccountCoinsRequest:
-		return b.isPChain(r.NetworkIdentifier)
+		return isPChain(r.NetworkIdentifier)
 	case *types.BlockRequest:
-		return b.isPChain(r.NetworkIdentifier)
+		return isPChain(r.NetworkIdentifier)
 	case *types.BlockTransactionRequest:
-		return b.isPChain(r.NetworkIdentifier)
+		return isPChain(r.NetworkIdentifier)
 	case *types.ConstructionDeriveRequest:
-		return b.isPChain(r.NetworkIdentifier)
+		return isPChain(r.NetworkIdentifier)
 	case *types.ConstructionMetadataRequest:
-		return b.isPChain(r.NetworkIdentifier)
+		return isPChain(r.NetworkIdentifier)
 	case *types.ConstructionPreprocessRequest:
-		return b.isPChain(r.NetworkIdentifier)
+		return isPChain(r.NetworkIdentifier)
 	case *types.ConstructionPayloadsRequest:
-		return b.isPChain(r.NetworkIdentifier)
+		return isPChain(r.NetworkIdentifier)
 	case *types.ConstructionParseRequest:
-		return b.isPChain(r.NetworkIdentifier)
+		return isPChain(r.NetworkIdentifier)
 	case *types.ConstructionCombineRequest:
-		return b.isPChain(r.NetworkIdentifier)
+		return isPChain(r.NetworkIdentifier)
 	case *types.ConstructionHashRequest:
-		return b.isPChain(r.NetworkIdentifier)
+		return isPChain(r.NetworkIdentifier)
 	case *types.ConstructionSubmitRequest:
-		return b.isPChain(r.NetworkIdentifier)
+		return isPChain(r.NetworkIdentifier)
 	case *types.NetworkRequest:
-		return b.isPChain(r.NetworkIdentifier)
+		return isPChain(r.NetworkIdentifier)
 	}
 
 	return false
 }
 
 // isPChain checks network identifier to make sure sub-network identifier set to "P"
-func (*Backend) isPChain(reqNetworkID *types.NetworkIdentifier) bool {
+func isPChain(reqNetworkID *types.NetworkIdentifier) bool {
 	return reqNetworkID != nil &&
 		reqNetworkID.SubNetworkIdentifier != nil &&
 		reqNetworkID.SubNetworkIdentifier.Network == constants.PChain.String()

--- a/service/backend/pchain/backend.go
+++ b/service/backend/pchain/backend.go
@@ -81,7 +81,7 @@ func NewBackend(
 }
 
 // ShouldHandleRequest returns whether a given request should be handled by this backend
-func (b *Backend) ShouldHandleRequest(req interface{}) bool {
+func (*Backend) ShouldHandleRequest(req interface{}) bool {
 	switch r := req.(type) {
 	case *types.AccountBalanceRequest:
 		return isPChain(r.NetworkIdentifier)

--- a/service/backend/pchain/backend_test.go
+++ b/service/backend/pchain/backend_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanche-rosetta/client"
@@ -42,7 +42,7 @@ func TestShouldHandleRequest(t *testing.T) {
 		pChainNetworkIdentifier,
 		avalancheNetworkID,
 	)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	testData := []struct {
 		name              string
@@ -72,7 +72,7 @@ func TestShouldHandleRequest(t *testing.T) {
 				&types.NetworkRequest{NetworkIdentifier: tc.networkIdentifier},
 			}
 			for _, r := range requests {
-				assert.Equal(t, tc.expected, backend.ShouldHandleRequest(r))
+				require.Equal(t, tc.expected, backend.ShouldHandleRequest(r))
 			}
 		})
 	}

--- a/service/backend/pchain/block.go
+++ b/service/backend/pchain/block.go
@@ -3,16 +3,15 @@ package pchain
 import (
 	"context"
 
-	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
-	"github.com/coinbase/rosetta-sdk-go/types"
-
-	"github.com/ava-labs/avalanche-rosetta/service"
-
 	"github.com/ava-labs/avalanchego/api"
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/coinbase/rosetta-sdk-go/types"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/ava-labs/avalanche-rosetta/service"
 
 	pmapper "github.com/ava-labs/avalanche-rosetta/mapper/pchain"
 )

--- a/service/backend/pchain/block.go
+++ b/service/backend/pchain/block.go
@@ -162,7 +162,7 @@ func (b *Backend) fetchBlkDependencies(ctx context.Context, txs []*txs.Tx) (pmap
 	blockDeps := make(pmapper.BlockTxDependencies)
 	depsTxIDs := []ids.ID{}
 	for _, tx := range txs {
-		inputTxsIds, err := blockDeps.GetTxDependenciesIDs(tx.Unsigned)
+		inputTxsIds, err := pmapper.GetTxDependenciesIDs(tx.Unsigned)
 		if err != nil {
 			return nil, err
 		}

--- a/service/backend/pchain/block_test.go
+++ b/service/backend/pchain/block_test.go
@@ -6,14 +6,12 @@ import (
 
 	"github.com/ava-labs/avalanchego/api"
 	"github.com/ava-labs/avalanchego/ids"
-	avaConst "github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/platformvm/block"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
-	avaTypes "github.com/ava-labs/avalanchego/vms/types"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -22,6 +20,9 @@ import (
 	"github.com/ava-labs/avalanche-rosetta/constants"
 	"github.com/ava-labs/avalanche-rosetta/service"
 	"github.com/ava-labs/avalanche-rosetta/service/backend/pchain/indexer"
+
+	avaconstants "github.com/ava-labs/avalanchego/utils/constants"
+	avatypes "github.com/ava-labs/avalanchego/vms/types"
 )
 
 func TestFetchBlkDependencies(t *testing.T) {
@@ -33,7 +34,7 @@ func TestFetchBlkDependencies(t *testing.T) {
 
 	ctx := context.Background()
 
-	networkID := avaConst.MainnetID
+	networkID := avaconstants.MainnetID
 	networkIdentifier := &types.NetworkIdentifier{
 		Blockchain: service.BlockchainName,
 		Network:    constants.MainnetNetwork,
@@ -127,7 +128,7 @@ func makeImportTx(t *testing.T, networkID uint32) (*txs.Tx, error) {
 					},
 				},
 				Ins:  []*avax.TransferableInput{},
-				Memo: avaTypes.JSONByteSlice{},
+				Memo: avatypes.JSONByteSlice{},
 			},
 			SyntacticallyVerified: false,
 		},

--- a/service/backend/pchain/block_test.go
+++ b/service/backend/pchain/block_test.go
@@ -104,7 +104,7 @@ func TestFetchBlkDependencies(t *testing.T) {
 	deps, err := backend.fetchBlkDependencies(ctx, []*txs.Tx{tx})
 	require.NoError(t, err)
 
-	require.Equal(t, 2, len(deps))
+	require.Len(t, deps, 2)
 	require.Equal(t, ids.Empty, deps[genesisTxID].Tx.ID())
 	require.NotEqual(t, ids.Empty, deps[nonGenesisTxID].Tx.ID())
 	require.Equal(t, signedImportTx, deps[nonGenesisTxID].Tx)

--- a/service/backend/pchain/block_test.go
+++ b/service/backend/pchain/block_test.go
@@ -43,7 +43,7 @@ func TestFetchBlkDependencies(t *testing.T) {
 	}
 
 	signedImportTx, err := makeImportTx(t, networkID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	genesisTxID := ids.Empty
 	nonGenesisTxID := signedImportTx.ID()
@@ -99,10 +99,10 @@ func TestFetchBlkDependencies(t *testing.T) {
 	}).Return(nil, nil)
 
 	backend, err := NewBackend(service.ModeOnline, mockPClient, mockIndexerParser, avaxAssetID, networkIdentifier, networkID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	deps, err := backend.fetchBlkDependencies(ctx, []*txs.Tx{tx})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, 2, len(deps))
 	require.Equal(t, ids.Empty, deps[genesisTxID].Tx.ID())
@@ -135,7 +135,7 @@ func makeImportTx(t *testing.T, networkID uint32) (*txs.Tx, error) {
 		ImportedInputs: []*avax.TransferableInput{},
 	}
 	signedImportTx, err := txs.NewSigned(importTx, block.Codec, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	signedImportTx.Creds = []verify.Verifiable{}
 	return signedImportTx, err
 }

--- a/service/backend/pchain/construction.go
+++ b/service/backend/pchain/construction.go
@@ -26,12 +26,12 @@ var (
 )
 
 // ConstructionDerive implements /construction/derive endpoint for P-chain
-func (b *Backend) ConstructionDerive(_ context.Context, req *types.ConstructionDeriveRequest) (*types.ConstructionDeriveResponse, *types.Error) {
+func (*Backend) ConstructionDerive(_ context.Context, req *types.ConstructionDeriveRequest) (*types.ConstructionDeriveResponse, *types.Error) {
 	return common.DeriveBech32Address(constants.PChain, req)
 }
 
 // ConstructionPreprocess implements /construction/preprocess endpoint for P-chain
-func (b *Backend) ConstructionPreprocess(
+func (*Backend) ConstructionPreprocess(
 	_ context.Context,
 	req *types.ConstructionPreprocessRequest,
 ) (*types.ConstructionPreprocessResponse, *types.Error) {
@@ -149,7 +149,7 @@ func (b *Backend) buildExportMetadata(ctx context.Context, options map[string]in
 	return &pmapper.Metadata{ExportMetadata: exportMetadata}, suggestedFee, nil
 }
 
-func (b *Backend) buildStakingMetadata(options map[string]interface{}) (*pmapper.Metadata, *types.Amount, error) {
+func (*Backend) buildStakingMetadata(options map[string]interface{}) (*pmapper.Metadata, *types.Amount, error) {
 	var preprocessOptions pmapper.StakingOptions
 	if err := mapper.UnmarshalJSONMap(options, &preprocessOptions); err != nil {
 		return nil, nil, err
@@ -225,7 +225,7 @@ func (b *Backend) ConstructionCombine(_ context.Context, req *types.Construction
 }
 
 // CombineTx implements P-chain specific logic for combining unsigned transactions and signatures
-func (b *Backend) CombineTx(tx common.AvaxTx, signatures []*types.Signature) (common.AvaxTx, *types.Error) {
+func (*Backend) CombineTx(tx common.AvaxTx, signatures []*types.Signature) (common.AvaxTx, *types.Error) {
 	pTx, ok := tx.(*pTx)
 	if !ok {
 		return nil, service.WrapError(service.ErrInvalidInput, "invalid transaction")

--- a/service/backend/pchain/construction.go
+++ b/service/backend/pchain/construction.go
@@ -15,9 +15,10 @@ import (
 
 	"github.com/ava-labs/avalanche-rosetta/constants"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
-	pmapper "github.com/ava-labs/avalanche-rosetta/mapper/pchain"
 	"github.com/ava-labs/avalanche-rosetta/service"
 	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
+
+	pmapper "github.com/ava-labs/avalanche-rosetta/mapper/pchain"
 )
 
 var (

--- a/service/backend/pchain/construction.go
+++ b/service/backend/pchain/construction.go
@@ -70,7 +70,7 @@ func (b *Backend) ConstructionMetadata(
 	case pmapper.OpExportAvax:
 		metadata, suggestedFee, err = b.buildExportMetadata(ctx, req.Options)
 	case pmapper.OpAddValidator, pmapper.OpAddDelegator:
-		metadata, suggestedFee, err = b.buildStakingMetadata(req.Options)
+		metadata, suggestedFee, err = buildStakingMetadata(req.Options)
 		metadata.Threshold = opMetadata.Threshold
 		metadata.Locktime = opMetadata.Locktime
 
@@ -150,7 +150,7 @@ func (b *Backend) buildExportMetadata(ctx context.Context, options map[string]in
 	return &pmapper.Metadata{ExportMetadata: exportMetadata}, suggestedFee, nil
 }
 
-func (*Backend) buildStakingMetadata(options map[string]interface{}) (*pmapper.Metadata, *types.Amount, error) {
+func buildStakingMetadata(options map[string]interface{}) (*pmapper.Metadata, *types.Amount, error) {
 	var preprocessOptions pmapper.StakingOptions
 	if err := mapper.UnmarshalJSONMap(options, &preprocessOptions); err != nil {
 		return nil, nil, err

--- a/service/backend/pchain/construction_test.go
+++ b/service/backend/pchain/construction_test.go
@@ -10,9 +10,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/ids"
-	avaConst "github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/formatting"
-	ajson "github.com/ava-labs/avalanchego/utils/json"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -23,6 +21,9 @@ import (
 	"github.com/ava-labs/avalanche-rosetta/service"
 	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
 	"github.com/ava-labs/avalanche-rosetta/service/backend/pchain/indexer"
+
+	avaconstants "github.com/ava-labs/avalanchego/utils/constants"
+	avajson "github.com/ava-labs/avalanchego/utils/json"
 )
 
 var (
@@ -43,7 +44,7 @@ var (
 
 	nodeID = "NodeID-Bvsx89JttQqhqdgwtizAPoVSNW74Xcr2S"
 
-	avalancheNetworkID = avaConst.FujiID
+	avalancheNetworkID = avaconstants.FujiID
 
 	avaxAssetID, _ = ids.FromString("U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK")
 
@@ -223,7 +224,7 @@ func TestExportTxConstruction(t *testing.T) {
 	})
 
 	t.Run("metadata endpoint", func(t *testing.T) {
-		clientMock.EXPECT().GetTxFee(ctx).Return(&info.GetTxFeeResponse{TxFee: ajson.Uint64(txFee)}, nil)
+		clientMock.EXPECT().GetTxFee(ctx).Return(&info.GetTxFeeResponse{TxFee: avajson.Uint64(txFee)}, nil)
 		clientMock.EXPECT().GetBlockchainID(ctx, constants.PChain.String()).Return(pChainID, nil)
 		clientMock.EXPECT().GetBlockchainID(ctx, constants.CChain.String()).Return(cChainID, nil)
 
@@ -436,7 +437,7 @@ func TestImportTxConstruction(t *testing.T) {
 	})
 
 	t.Run("metadata endpoint", func(t *testing.T) {
-		clientMock.EXPECT().GetTxFee(ctx).Return(&info.GetTxFeeResponse{TxFee: ajson.Uint64(txFee)}, nil)
+		clientMock.EXPECT().GetTxFee(ctx).Return(&info.GetTxFeeResponse{TxFee: avajson.Uint64(txFee)}, nil)
 		clientMock.EXPECT().GetBlockchainID(ctx, constants.PChain.String()).Return(pChainID, nil)
 		clientMock.EXPECT().GetBlockchainID(ctx, constants.CChain.String()).Return(cChainID, nil)
 

--- a/service/backend/pchain/construction_test.go
+++ b/service/backend/pchain/construction_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	ajson "github.com/ava-labs/avalanchego/utils/json"
 	"github.com/coinbase/rosetta-sdk-go/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanche-rosetta/client"
@@ -84,7 +84,7 @@ func TestConstructionDerive(t *testing.T) {
 		pChainNetworkIdentifier,
 		avalancheNetworkID,
 	)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	t.Run("p-chain address", func(t *testing.T) {
 		src := "02e0d4392cfa224d4be19db416b3cf62e90fb2b7015e7b62a95c8cb490514943f6"
@@ -100,8 +100,8 @@ func TestConstructionDerive(t *testing.T) {
 				},
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(
+		require.Nil(t, err)
+		require.Equal(
 			t,
 			"P-fuji15f9g0h5xkr5cp47n6u3qxj6yjtzzzrdr23a3tl",
 			resp.AccountIdentifier.Address,
@@ -203,7 +203,7 @@ func TestExportTxConstruction(t *testing.T) {
 		pChainNetworkIdentifier,
 		avalancheNetworkID,
 	)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	t.Run("preprocess endpoint", func(t *testing.T) {
 		resp, err := backend.ConstructionPreprocess(
@@ -214,8 +214,8 @@ func TestExportTxConstruction(t *testing.T) {
 				Metadata:          preprocessMetadata,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, metadataOptions, resp.Options)
+		require.Nil(t, err)
+		require.Equal(t, metadataOptions, resp.Options)
 	})
 
 	t.Run("metadata endpoint", func(t *testing.T) {
@@ -230,8 +230,8 @@ func TestExportTxConstruction(t *testing.T) {
 				Options:           metadataOptions,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, payloadsMetadata, resp.Metadata)
+		require.Nil(t, err)
+		require.Equal(t, payloadsMetadata, resp.Metadata)
 	})
 
 	t.Run("payloads endpoint", func(t *testing.T) {
@@ -243,9 +243,9 @@ func TestExportTxConstruction(t *testing.T) {
 				Metadata:          payloadsMetadata,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, wrappedUnsignedExportTx, resp.UnsignedTransaction)
-		assert.Equal(t, signingPayloads, resp.Payloads,
+		require.Nil(t, err)
+		require.Equal(t, wrappedUnsignedExportTx, resp.UnsignedTransaction)
+		require.Equal(t, signingPayloads, resp.Payloads,
 			"signing payloads mismatch: %s %s",
 			marshalSigningPayloads(signingPayloads),
 			marshalSigningPayloads(resp.Payloads))
@@ -260,9 +260,9 @@ func TestExportTxConstruction(t *testing.T) {
 				Signed:            false,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Nil(t, resp.AccountIdentifierSigners)
-		assert.Equal(t, exportOperations, resp.Operations)
+		require.Nil(t, err)
+		require.Nil(t, resp.AccountIdentifierSigners)
+		require.Equal(t, exportOperations, resp.Operations)
 	})
 
 	t.Run("combine endpoint", func(t *testing.T) {
@@ -275,8 +275,8 @@ func TestExportTxConstruction(t *testing.T) {
 			},
 		)
 
-		assert.Nil(t, err)
-		assert.Equal(t, wrappedSignedExportTx, resp.SignedTransaction)
+		require.Nil(t, err)
+		require.Equal(t, wrappedSignedExportTx, resp.SignedTransaction)
 	})
 
 	t.Run("parse endpoint (signed)", func(t *testing.T) {
@@ -288,9 +288,9 @@ func TestExportTxConstruction(t *testing.T) {
 				Signed:            true,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, signers, resp.AccountIdentifierSigners)
-		assert.Equal(t, exportOperations, resp.Operations)
+		require.Nil(t, err)
+		require.Equal(t, signers, resp.AccountIdentifierSigners)
+		require.Equal(t, exportOperations, resp.Operations)
 	})
 
 	t.Run("hash endpoint", func(t *testing.T) {
@@ -298,8 +298,8 @@ func TestExportTxConstruction(t *testing.T) {
 			NetworkIdentifier: pChainNetworkIdentifier,
 			SignedTransaction: wrappedSignedExportTx,
 		})
-		assert.Nil(t, err)
-		assert.Equal(t, signedExportTxHash, resp.TransactionIdentifier.Hash)
+		require.Nil(t, err)
+		require.Equal(t, signedExportTxHash, resp.TransactionIdentifier.Hash)
 	})
 
 	t.Run("submit endpoint", func(t *testing.T) {
@@ -313,8 +313,8 @@ func TestExportTxConstruction(t *testing.T) {
 			SignedTransaction: wrappedSignedExportTx,
 		})
 
-		assert.Nil(t, apiErr)
-		assert.Equal(t, signedExportTxHash, resp.TransactionIdentifier.Hash)
+		require.Nil(t, apiErr)
+		require.Equal(t, signedExportTxHash, resp.TransactionIdentifier.Hash)
 	})
 }
 
@@ -410,7 +410,7 @@ func TestImportTxConstruction(t *testing.T) {
 		pChainNetworkIdentifier,
 		avalancheNetworkID,
 	)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	t.Run("preprocess endpoint", func(t *testing.T) {
 		resp, err := backend.ConstructionPreprocess(
@@ -421,8 +421,8 @@ func TestImportTxConstruction(t *testing.T) {
 				Metadata:          preprocessMetadata,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, metadataOptions, resp.Options)
+		require.Nil(t, err)
+		require.Equal(t, metadataOptions, resp.Options)
 	})
 
 	t.Run("metadata endpoint", func(t *testing.T) {
@@ -437,8 +437,8 @@ func TestImportTxConstruction(t *testing.T) {
 				Options:           metadataOptions,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, payloadsMetadata, resp.Metadata)
+		require.Nil(t, err)
+		require.Equal(t, payloadsMetadata, resp.Metadata)
 	})
 
 	t.Run("payloads endpoint", func(t *testing.T) {
@@ -450,9 +450,9 @@ func TestImportTxConstruction(t *testing.T) {
 				Metadata:          payloadsMetadata,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, wrappedUnsignedImportTx, resp.UnsignedTransaction)
-		assert.Equal(t, signingPayloads, resp.Payloads,
+		require.Nil(t, err)
+		require.Equal(t, wrappedUnsignedImportTx, resp.UnsignedTransaction)
+		require.Equal(t, signingPayloads, resp.Payloads,
 			"signing payloads mismatch: %s %s",
 			marshalSigningPayloads(signingPayloads),
 			marshalSigningPayloads(resp.Payloads))
@@ -467,9 +467,9 @@ func TestImportTxConstruction(t *testing.T) {
 				Signed:            false,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Nil(t, resp.AccountIdentifierSigners)
-		assert.Equal(t, importOperations, resp.Operations)
+		require.Nil(t, err)
+		require.Nil(t, resp.AccountIdentifierSigners)
+		require.Equal(t, importOperations, resp.Operations)
 	})
 
 	t.Run("combine endpoint", func(t *testing.T) {
@@ -482,8 +482,8 @@ func TestImportTxConstruction(t *testing.T) {
 			},
 		)
 
-		assert.Nil(t, err)
-		assert.Equal(t, wrappedSignedImportTx, resp.SignedTransaction)
+		require.Nil(t, err)
+		require.Equal(t, wrappedSignedImportTx, resp.SignedTransaction)
 	})
 
 	t.Run("parse endpoint (signed)", func(t *testing.T) {
@@ -495,9 +495,9 @@ func TestImportTxConstruction(t *testing.T) {
 				Signed:            true,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, signers, resp.AccountIdentifierSigners)
-		assert.Equal(t, importOperations, resp.Operations)
+		require.Nil(t, err)
+		require.Equal(t, signers, resp.AccountIdentifierSigners)
+		require.Equal(t, importOperations, resp.Operations)
 	})
 
 	t.Run("hash endpoint", func(t *testing.T) {
@@ -505,8 +505,8 @@ func TestImportTxConstruction(t *testing.T) {
 			NetworkIdentifier: pChainNetworkIdentifier,
 			SignedTransaction: wrappedSignedImportTx,
 		})
-		assert.Nil(t, err)
-		assert.Equal(t, signedImportTxHash, resp.TransactionIdentifier.Hash)
+		require.Nil(t, err)
+		require.Equal(t, signedImportTxHash, resp.TransactionIdentifier.Hash)
 	})
 
 	t.Run("submit endpoint", func(t *testing.T) {
@@ -520,8 +520,8 @@ func TestImportTxConstruction(t *testing.T) {
 			SignedTransaction: wrappedSignedImportTx,
 		})
 
-		assert.Nil(t, apiErr)
-		assert.Equal(t, signedImportTxHash, resp.TransactionIdentifier.Hash)
+		require.Nil(t, apiErr)
+		require.Equal(t, signedImportTxHash, resp.TransactionIdentifier.Hash)
 	})
 }
 
@@ -640,7 +640,7 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 		pChainNetworkIdentifier,
 		avalancheNetworkID,
 	)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	t.Run("preprocess endpoint", func(t *testing.T) {
 		resp, err := backend.ConstructionPreprocess(
@@ -651,8 +651,8 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 				Metadata:          preprocessMetadata,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, metadataOptions, resp.Options)
+		require.Nil(t, err)
+		require.Equal(t, metadataOptions, resp.Options)
 	})
 
 	t.Run("metadata endpoint", func(t *testing.T) {
@@ -665,8 +665,8 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 				Options:           metadataOptions,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, payloadsMetadata, resp.Metadata)
+		require.Nil(t, err)
+		require.Equal(t, payloadsMetadata, resp.Metadata)
 	})
 
 	t.Run("payloads endpoint", func(t *testing.T) {
@@ -678,9 +678,9 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 				Metadata:          payloadsMetadata,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, wrappedUnsignedTx, resp.UnsignedTransaction)
-		assert.Equal(t, signingPayloads, resp.Payloads,
+		require.Nil(t, err)
+		require.Equal(t, wrappedUnsignedTx, resp.UnsignedTransaction)
+		require.Equal(t, signingPayloads, resp.Payloads,
 			"signing payloads mismatch: %s %s",
 			marshalSigningPayloads(signingPayloads),
 			marshalSigningPayloads(resp.Payloads))
@@ -695,9 +695,9 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 				Signed:            false,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Nil(t, resp.AccountIdentifierSigners)
-		assert.Equal(t, operations, resp.Operations)
+		require.Nil(t, err)
+		require.Nil(t, resp.AccountIdentifierSigners)
+		require.Equal(t, operations, resp.Operations)
 	})
 
 	t.Run("combine endpoint", func(t *testing.T) {
@@ -710,8 +710,8 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 			},
 		)
 
-		assert.Nil(t, err)
-		assert.Equal(t, wrappedSignedTx, resp.SignedTransaction)
+		require.Nil(t, err)
+		require.Equal(t, wrappedSignedTx, resp.SignedTransaction)
 	})
 
 	t.Run("parse endpoint (signed)", func(t *testing.T) {
@@ -723,9 +723,9 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 				Signed:            true,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, signers, resp.AccountIdentifierSigners)
-		assert.Equal(t, operations, resp.Operations)
+		require.Nil(t, err)
+		require.Equal(t, signers, resp.AccountIdentifierSigners)
+		require.Equal(t, operations, resp.Operations)
 	})
 
 	t.Run("hash endpoint", func(t *testing.T) {
@@ -733,8 +733,8 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 			NetworkIdentifier: pChainNetworkIdentifier,
 			SignedTransaction: wrappedSignedTx,
 		})
-		assert.Nil(t, err)
-		assert.Equal(t, signedTxHash, resp.TransactionIdentifier.Hash)
+		require.Nil(t, err)
+		require.Equal(t, signedTxHash, resp.TransactionIdentifier.Hash)
 	})
 
 	t.Run("submit endpoint", func(t *testing.T) {
@@ -748,8 +748,8 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 			SignedTransaction: wrappedSignedTx,
 		})
 
-		assert.Nil(t, apiErr)
-		assert.Equal(t, signedTxHash, resp.TransactionIdentifier.Hash)
+		require.Nil(t, apiErr)
+		require.Equal(t, signedTxHash, resp.TransactionIdentifier.Hash)
 	})
 }
 
@@ -865,7 +865,7 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 		pChainNetworkIdentifier,
 		avalancheNetworkID,
 	)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	t.Run("preprocess endpoint", func(t *testing.T) {
 		resp, err := backend.ConstructionPreprocess(
@@ -876,8 +876,8 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 				Metadata:          preprocessMetadata,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, metadataOptions, resp.Options)
+		require.Nil(t, err)
+		require.Equal(t, metadataOptions, resp.Options)
 	})
 
 	t.Run("metadata endpoint", func(t *testing.T) {
@@ -890,8 +890,8 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 				Options:           metadataOptions,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, payloadsMetadata, resp.Metadata)
+		require.Nil(t, err)
+		require.Equal(t, payloadsMetadata, resp.Metadata)
 	})
 
 	t.Run("payloads endpoint", func(t *testing.T) {
@@ -903,9 +903,9 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 				Metadata:          payloadsMetadata,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, wrappedUnsignedTx, resp.UnsignedTransaction)
-		assert.Equal(t, signingPayloads, resp.Payloads,
+		require.Nil(t, err)
+		require.Equal(t, wrappedUnsignedTx, resp.UnsignedTransaction)
+		require.Equal(t, signingPayloads, resp.Payloads,
 			"signing payloads mismatch: %s %s",
 			marshalSigningPayloads(signingPayloads),
 			marshalSigningPayloads(resp.Payloads))
@@ -920,9 +920,9 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 				Signed:            false,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Nil(t, resp.AccountIdentifierSigners)
-		assert.Equal(t, operations, resp.Operations)
+		require.Nil(t, err)
+		require.Nil(t, resp.AccountIdentifierSigners)
+		require.Equal(t, operations, resp.Operations)
 	})
 
 	t.Run("combine endpoint", func(t *testing.T) {
@@ -935,8 +935,8 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 			},
 		)
 
-		assert.Nil(t, err)
-		assert.Equal(t, wrappedSignedTx, resp.SignedTransaction)
+		require.Nil(t, err)
+		require.Equal(t, wrappedSignedTx, resp.SignedTransaction)
 	})
 
 	t.Run("parse endpoint (signed)", func(t *testing.T) {
@@ -948,9 +948,9 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 				Signed:            true,
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, signers, resp.AccountIdentifierSigners)
-		assert.Equal(t, operations, resp.Operations)
+		require.Nil(t, err)
+		require.Equal(t, signers, resp.AccountIdentifierSigners)
+		require.Equal(t, operations, resp.Operations)
 	})
 
 	t.Run("hash endpoint", func(t *testing.T) {
@@ -958,8 +958,8 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 			NetworkIdentifier: pChainNetworkIdentifier,
 			SignedTransaction: wrappedSignedTx,
 		})
-		assert.Nil(t, err)
-		assert.Equal(t, signedTxHash, resp.TransactionIdentifier.Hash)
+		require.Nil(t, err)
+		require.Equal(t, signedTxHash, resp.TransactionIdentifier.Hash)
 	})
 
 	t.Run("submit endpoint", func(t *testing.T) {
@@ -973,8 +973,8 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 			SignedTransaction: wrappedSignedTx,
 		})
 
-		assert.Nil(t, apiErr)
-		assert.Equal(t, signedTxHash, resp.TransactionIdentifier.Hash)
+		require.Nil(t, apiErr)
+		require.Equal(t, signedTxHash, resp.TransactionIdentifier.Hash)
 	})
 }
 

--- a/service/backend/pchain/construction_test.go
+++ b/service/backend/pchain/construction_test.go
@@ -316,12 +316,12 @@ func TestExportTxConstruction(t *testing.T) {
 
 		clientMock.EXPECT().IssueTx(ctx, signedTxBytes).Return(txID, nil)
 
-		resp, apiErr := backend.ConstructionSubmit(ctx, &types.ConstructionSubmitRequest{
+		resp, terr := backend.ConstructionSubmit(ctx, &types.ConstructionSubmitRequest{
 			NetworkIdentifier: pChainNetworkIdentifier,
 			SignedTransaction: wrappedSignedExportTx,
 		})
 
-		require.Nil(apiErr)
+		require.Nil(terr)
 		require.Equal(signedExportTxHash, resp.TransactionIdentifier.Hash)
 	})
 }
@@ -530,12 +530,12 @@ func TestImportTxConstruction(t *testing.T) {
 
 		clientMock.EXPECT().IssueTx(ctx, signedTxBytes).Return(txID, nil)
 
-		resp, apiErr := backend.ConstructionSubmit(ctx, &types.ConstructionSubmitRequest{
+		resp, terr := backend.ConstructionSubmit(ctx, &types.ConstructionSubmitRequest{
 			NetworkIdentifier: pChainNetworkIdentifier,
 			SignedTransaction: wrappedSignedImportTx,
 		})
 
-		require.Nil(apiErr)
+		require.Nil(terr)
 		require.Equal(signedImportTxHash, resp.TransactionIdentifier.Hash)
 	})
 }
@@ -764,12 +764,12 @@ func TestAddValidatorTxConstruction(t *testing.T) {
 
 		clientMock.EXPECT().IssueTx(ctx, signedTxBytes).Return(txID, nil)
 
-		resp, apiErr := backend.ConstructionSubmit(ctx, &types.ConstructionSubmitRequest{
+		resp, terr := backend.ConstructionSubmit(ctx, &types.ConstructionSubmitRequest{
 			NetworkIdentifier: pChainNetworkIdentifier,
 			SignedTransaction: wrappedSignedTx,
 		})
 
-		require.Nil(apiErr)
+		require.Nil(terr)
 		require.Equal(signedTxHash, resp.TransactionIdentifier.Hash)
 	})
 }
@@ -995,12 +995,12 @@ func TestAddDelegatorTxConstruction(t *testing.T) {
 
 		clientMock.EXPECT().IssueTx(ctx, signedTxBytes).Return(txID, nil)
 
-		resp, apiErr := backend.ConstructionSubmit(ctx, &types.ConstructionSubmitRequest{
+		resp, terr := backend.ConstructionSubmit(ctx, &types.ConstructionSubmitRequest{
 			NetworkIdentifier: pChainNetworkIdentifier,
 			SignedTransaction: wrappedSignedTx,
 		})
 
-		require.Nil(apiErr)
+		require.Nil(terr)
 		require.Equal(signedTxHash, resp.TransactionIdentifier.Hash)
 	})
 }

--- a/service/backend/pchain/indexer/parser_test.go
+++ b/service/backend/pchain/indexer/parser_test.go
@@ -2,25 +2,25 @@ package indexer
 
 import (
 	"context"
-	stdjson "encoding/json"
+	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
 
-	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/avalanchego/utils/constants"
-	pGenesis "github.com/ava-labs/avalanchego/vms/platformvm/genesis"
-	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
-	"github.com/stretchr/testify/require"
-	gomock "go.uber.org/mock/gomock"
-
-	"github.com/ava-labs/avalanche-rosetta/client"
-	rosConst "github.com/ava-labs/avalanche-rosetta/constants"
-
 	"github.com/ava-labs/avalanchego/api"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/indexer"
+	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/formatting"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/ava-labs/avalanche-rosetta/client"
+	"github.com/ava-labs/avalanche-rosetta/constants"
+
+	avaconstants "github.com/ava-labs/avalanchego/utils/constants"
 )
 
 var (
@@ -53,7 +53,7 @@ var idxs = []uint64{
 
 func readFixture(path string, sprintfArgs ...interface{}) []byte {
 	relpath := fmt.Sprintf(path, sprintfArgs...)
-	ret, err := os.ReadFile(fmt.Sprintf("testdata/%s", relpath))
+	ret, err := os.ReadFile("testdata/" + relpath)
 	if err != nil {
 		panic(err)
 	}
@@ -69,7 +69,7 @@ func TestMain(m *testing.M) {
 		ret := readFixture("ins/%v.json", idx)
 
 		var container indexer.Container
-		err := stdjson.Unmarshal(ret, &container)
+		err := json.Unmarshal(ret, &container)
 		if err != nil {
 			panic(err)
 		}
@@ -90,7 +90,7 @@ func TestMain(m *testing.M) {
 
 	pchainClient.EXPECT().GetHeight(ctx, gomock.Any()).Return(uint64(1000000), nil)
 
-	p, err = NewParser(pchainClient, constants.MainnetID)
+	p, err = NewParser(pchainClient, avaconstants.MainnetID)
 	if err != nil {
 		panic(err)
 	}
@@ -112,9 +112,9 @@ func TestGenesisBlockCreateChainTxs(t *testing.T) {
 		castTx.GenesisData = []byte{}
 	}
 
-	g.UTXOs = []*pGenesis.UTXO{}
+	g.UTXOs = []*genesis.UTXO{}
 
-	j, err := stdjson.Marshal(g)
+	j, err := json.Marshal(g)
 	require.NoError(err)
 
 	ret := readFixture("outs/genesis.json")
@@ -126,15 +126,15 @@ func TestGenesisBlockParseTxs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	pchainClient := client.NewMockPChainClient(ctrl)
 
-	p, err := NewParser(pchainClient, constants.FujiID)
+	p, err := NewParser(pchainClient, avaconstants.FujiID)
 	require.NoError(err)
 
 	ctx := context.Background()
 	g, err := p.GetGenesisBlock(ctx)
 	require.NoError(err)
 
-	initializeTxCtx(g.Txs, constants.FujiID)
-	j, err := stdjson.MarshalIndent(g, "", "  ")
+	initializeTxCtx(g.Txs, avaconstants.FujiID)
+	j, err := json.MarshalIndent(g, "", "  ")
 	require.NoError(err)
 
 	ret := readFixture("outs/genesis_fuji_txs.json")
@@ -152,8 +152,8 @@ func TestFixtures(t *testing.T) {
 		block, err := p.ParseNonGenesisBlock(ctx, "", idx+1)
 		require.NoError(err)
 
-		initializeTxCtx(block.Txs, constants.MainnetID)
-		j, err := stdjson.Marshal(block)
+		initializeTxCtx(block.Txs, avaconstants.MainnetID)
+		j, err := json.Marshal(block)
 		require.NoError(err)
 
 		ret := readFixture("outs/%v.json", idx)
@@ -163,7 +163,7 @@ func TestFixtures(t *testing.T) {
 
 func initializeTxCtx(txs []*txs.Tx, networkID uint32) {
 	aliaser := ids.NewAliaser()
-	_ = aliaser.Alias(constants.PlatformChainID, rosConst.PChain.String())
+	_ = aliaser.Alias(avaconstants.PlatformChainID, constants.PChain.String())
 	ctx := &snow.Context{
 		BCLookup:  aliaser,
 		NetworkID: networkID,

--- a/service/backend/pchain/indexer/parser_test.go
+++ b/service/backend/pchain/indexer/parser_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/constants"
 	pGenesis "github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/stretchr/testify/require"
 	gomock "go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanche-rosetta/client"
@@ -20,7 +21,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/indexer"
 	"github.com/ava-labs/avalanchego/utils/formatting"
-	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -104,7 +104,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestGenesisBlockCreateChainTxs(t *testing.T) {
-	a := assert.New(t)
+	require := require.New(t)
 
 	g.Txs = g.Txs[(len(g.Txs) - 2):]
 	for _, tx := range g.Txs {
@@ -115,61 +115,49 @@ func TestGenesisBlockCreateChainTxs(t *testing.T) {
 	g.UTXOs = []*pGenesis.UTXO{}
 
 	j, err := stdjson.Marshal(g)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(err)
 
 	ret := readFixture("outs/genesis.json")
-	a.JSONEq(string(ret), string(j))
+	require.JSONEq(string(ret), string(j))
 }
 
 func TestGenesisBlockParseTxs(t *testing.T) {
-	a := assert.New(t)
+	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	pchainClient := client.NewMockPChainClient(ctrl)
 
 	p, err := NewParser(pchainClient, constants.FujiID)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(err)
 
 	ctx := context.Background()
 	g, err := p.GetGenesisBlock(ctx)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(err)
 
 	initializeTxCtx(g.Txs, constants.FujiID)
 	j, err := stdjson.MarshalIndent(g, "", "  ")
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(err)
 
 	ret := readFixture("outs/genesis_fuji_txs.json")
-	a.JSONEq(string(ret), string(j))
+	require.JSONEq(string(ret), string(j))
 }
 
 func TestFixtures(t *testing.T) {
+	require := require.New(t)
 	ctx := context.Background()
-	a := assert.New(t)
 
 	for _, idx := range idxs {
 		// +1 because we do -1 inside parseBlockAtIndex
 		// and ins/outs are based on container ids
 		// instead of block ids
 		block, err := p.ParseNonGenesisBlock(ctx, "", idx+1)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(err)
 
 		initializeTxCtx(block.Txs, constants.MainnetID)
 		j, err := stdjson.Marshal(block)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(err)
 
 		ret := readFixture("outs/%v.json", idx)
-		a.JSONEq(string(ret), string(j))
+		require.JSONEq(string(ret), string(j))
 	}
 }
 

--- a/service/backend/pchain/network.go
+++ b/service/backend/pchain/network.go
@@ -62,7 +62,7 @@ func (b *Backend) NetworkStatus(ctx context.Context, _ *types.NetworkRequest) (*
 }
 
 // NetworkOptions implements /network/options endpoint for P-chain
-func (b *Backend) NetworkOptions(_ context.Context, _ *types.NetworkRequest) (*types.NetworkOptionsResponse, *types.Error) {
+func (*Backend) NetworkOptions(_ context.Context, _ *types.NetworkRequest) (*types.NetworkOptionsResponse, *types.Error) {
 	return &types.NetworkOptionsResponse{
 		Version: &types.Version{
 			RosettaVersion:    types.RosettaAPIVersion,

--- a/service/backend/pchain/network.go
+++ b/service/backend/pchain/network.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/ava-labs/avalanche-rosetta/constants"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
-	pmapper "github.com/ava-labs/avalanche-rosetta/mapper/pchain"
 	"github.com/ava-labs/avalanche-rosetta/service"
+
+	pmapper "github.com/ava-labs/avalanche-rosetta/mapper/pchain"
 )
 
 // NetworkIdentifier returns P-chain network identifier

--- a/service/backend/pchain/types.go
+++ b/service/backend/pchain/types.go
@@ -11,9 +11,10 @@ import (
 
 	"github.com/ava-labs/avalanche-rosetta/constants"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
-	pmapper "github.com/ava-labs/avalanche-rosetta/mapper/pchain"
 	"github.com/ava-labs/avalanche-rosetta/service"
 	"github.com/ava-labs/avalanche-rosetta/service/backend/common"
+
+	pmapper "github.com/ava-labs/avalanche-rosetta/mapper/pchain"
 )
 
 var (

--- a/service/config.go
+++ b/service/config.go
@@ -3,9 +3,10 @@ package service
 import (
 	"math/big"
 
-	ethtypes "github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/params"
 	"github.com/coinbase/rosetta-sdk-go/types"
+
+	ethtypes "github.com/ava-labs/coreth/core/types"
 )
 
 // Config holds the service configuration

--- a/service/config_test.go
+++ b/service/config_test.go
@@ -6,7 +6,7 @@ import (
 	ethtypes "github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/params"
 	"github.com/coinbase/rosetta-sdk-go/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfig(t *testing.T) {
@@ -17,8 +17,8 @@ func TestConfig(t *testing.T) {
 			NetworkID: &types.NetworkIdentifier{},
 		}
 
-		assert.Equal(t, false, cfg.IsOfflineMode())
-		assert.Equal(t, true, cfg.IsOnlineMode())
+		require.Equal(t, false, cfg.IsOfflineMode())
+		require.Equal(t, true, cfg.IsOnlineMode())
 	})
 
 	t.Run("offline", func(t *testing.T) {
@@ -28,14 +28,14 @@ func TestConfig(t *testing.T) {
 			NetworkID: &types.NetworkIdentifier{},
 		}
 
-		assert.Equal(t, true, cfg.IsOfflineMode())
-		assert.Equal(t, false, cfg.IsOnlineMode())
+		require.Equal(t, true, cfg.IsOfflineMode())
+		require.Equal(t, false, cfg.IsOnlineMode())
 	})
 
 	t.Run("signer", func(t *testing.T) {
 		cfg := Config{
 			ChainID: params.AvalancheMainnetChainID,
 		}
-		assert.IsType(t, ethtypes.NewLondonSigner(params.AvalancheMainnetChainID), cfg.Signer())
+		require.IsType(t, ethtypes.NewLondonSigner(params.AvalancheMainnetChainID), cfg.Signer())
 	})
 }

--- a/service/config_test.go
+++ b/service/config_test.go
@@ -17,8 +17,8 @@ func TestConfig(t *testing.T) {
 			NetworkID: &types.NetworkIdentifier{},
 		}
 
-		require.Equal(t, false, cfg.IsOfflineMode())
-		require.Equal(t, true, cfg.IsOnlineMode())
+		require.False(t, cfg.IsOfflineMode())
+		require.True(t, cfg.IsOnlineMode())
 	})
 
 	t.Run("offline", func(t *testing.T) {
@@ -28,8 +28,8 @@ func TestConfig(t *testing.T) {
 			NetworkID: &types.NetworkIdentifier{},
 		}
 
-		require.Equal(t, true, cfg.IsOfflineMode())
-		require.Equal(t, false, cfg.IsOnlineMode())
+		require.True(t, cfg.IsOfflineMode())
+		require.False(t, cfg.IsOnlineMode())
 	})
 
 	t.Run("signer", func(t *testing.T) {

--- a/service/config_test.go
+++ b/service/config_test.go
@@ -3,10 +3,11 @@ package service
 import (
 	"testing"
 
-	ethtypes "github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/params"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/stretchr/testify/require"
+
+	ethtypes "github.com/ava-labs/coreth/core/types"
 )
 
 func TestConfig(t *testing.T) {

--- a/service/contract_call_data.go
+++ b/service/contract_call_data.go
@@ -175,7 +175,7 @@ func encodeMethodArgsStrings(methodID []byte, methodSig string, methodArgs []str
 // signature for function call on contract
 func contractCallMethodID(methodSig string) ([]byte, error) {
 	if len(methodSig) < 4 {
-		return nil, fmt.Errorf("method signature is empty or too small")
+		return nil, errors.New("method signature is empty or too small")
 	}
 	return crypto.Keccak256([]byte(methodSig))[:4], nil
 }

--- a/service/contract_call_data_test.go
+++ b/service/contract_call_data_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConstruction_ContractCallData(t *testing.T) {
@@ -59,9 +59,9 @@ func TestConstruction_ContractCallData(t *testing.T) {
 			bytes, err := constructContractCallDataGeneric(test.methodSig, test.methodArgs)
 			if err != nil {
 				fmt.Println(err)
-				assert.EqualError(t, err, test.expectedError.Error())
+				require.EqualError(t, err, test.expectedError.Error())
 			} else {
-				assert.Equal(t, test.expectedResponse, hexutil.Encode(bytes))
+				require.Equal(t, test.expectedResponse, hexutil.Encode(bytes))
 			}
 		})
 	}

--- a/service/errors.go
+++ b/service/errors.go
@@ -56,11 +56,11 @@ func WrapError(err *types.Error, message interface{}) *types.Error {
 		newErr.Details[k] = v
 	}
 
-	switch t := message.(type) {
+	switch castMsg := message.(type) {
 	case error:
-		newErr.Details["error"] = t.Error()
+		newErr.Details["error"] = castMsg.Error()
 	default:
-		newErr.Details["error"] = t
+		newErr.Details["error"] = castMsg
 	}
 
 	return newErr

--- a/service/helper.go
+++ b/service/helper.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ava-labs/avalanche-rosetta/client"
 
 	ethtypes "github.com/ava-labs/coreth/core/types"
-	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 const (
@@ -54,7 +54,7 @@ func blockHeaderFromInput(
 		if input.Index != nil {
 			header, err = c.HeaderByNumber(ctx, big.NewInt(*input.Index))
 		} else {
-			header, err = c.HeaderByHash(ctx, ethcommon.HexToHash(*input.Hash))
+			header, err = c.HeaderByHash(ctx, common.HexToHash(*input.Hash))
 		}
 	}
 
@@ -73,7 +73,7 @@ func ChecksumAddress(address string) (string, bool) {
 		return "", false
 	}
 
-	addr, err := ethcommon.NewMixedcaseAddressFromString(address)
+	addr, err := common.NewMixedcaseAddressFromString(address)
 	if err != nil {
 		return "", false
 	}

--- a/service/helper_test.go
+++ b/service/helper_test.go
@@ -3,42 +3,42 @@ package service
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChecksumAddress(t *testing.T) {
 	t.Run("valid checksum address", func(t *testing.T) {
 		testAddr := "0x05da63494DfbfF6AA215E074D34aC9A25B616eF2"
 		addr, ok := ChecksumAddress(testAddr)
-		assert.True(t, ok)
-		assert.Equal(t, testAddr, addr)
+		require.True(t, ok)
+		require.Equal(t, testAddr, addr)
 	})
 
 	t.Run("modified checksum address", func(t *testing.T) {
 		testAddr := "0x05da63494DfbfF6AA215E074D34aC9A25B616ef2"
 		addr, ok := ChecksumAddress(testAddr)
-		assert.True(t, ok)
-		assert.Equal(t, "0x05da63494DfbfF6AA215E074D34aC9A25B616eF2", addr)
+		require.True(t, ok)
+		require.Equal(t, "0x05da63494DfbfF6AA215E074D34aC9A25B616eF2", addr)
 	})
 
 	t.Run("invalid hex", func(t *testing.T) {
 		testAddr := "0x05da63494DfbfF6AA215E074D34aC9A25B616eK2"
 		addr, ok := ChecksumAddress(testAddr)
-		assert.False(t, ok)
-		assert.Equal(t, "", addr)
+		require.False(t, ok)
+		require.Equal(t, "", addr)
 	})
 
 	t.Run("invalid length", func(t *testing.T) {
 		testAddr := "0x05da63494DfbfF6AA215E074D34aC9A25B"
 		addr, ok := ChecksumAddress(testAddr)
-		assert.False(t, ok)
-		assert.Equal(t, "", addr)
+		require.False(t, ok)
+		require.Equal(t, "", addr)
 	})
 
 	t.Run("missing 0x", func(t *testing.T) {
 		testAddr := "05da63494DfbfF6AA215E074D34aC9A25B616eF2"
 		addr, ok := ChecksumAddress(testAddr)
-		assert.False(t, ok)
-		assert.Equal(t, "", addr)
+		require.False(t, ok)
+		require.Equal(t, "", addr)
 	})
 }

--- a/service/service_account.go
+++ b/service/service_account.go
@@ -5,17 +5,16 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ava-labs/coreth/interfaces"
 	"github.com/coinbase/rosetta-sdk-go/server"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/coinbase/rosetta-sdk-go/utils"
-
-	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-
-	"github.com/ava-labs/coreth/interfaces"
 
 	"github.com/ava-labs/avalanche-rosetta/client"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 // AccountBackend represents a backend that implements /account family of apis for a subset of requests.

--- a/service/service_account.go
+++ b/service/service_account.go
@@ -9,12 +9,11 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/server"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/coinbase/rosetta-sdk-go/utils"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/ava-labs/avalanche-rosetta/client"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
-
-	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 // AccountBackend represents a backend that implements /account family of apis for a subset of requests.
@@ -82,7 +81,7 @@ func (s AccountService) AccountBalance(
 		return nil, terr
 	}
 
-	address := ethcommon.HexToAddress(req.AccountIdentifier.Address)
+	address := common.HexToAddress(req.AccountIdentifier.Address)
 
 	nonce, err := s.client.NonceAt(ctx, address, header.Number)
 	if err != nil {
@@ -128,7 +127,7 @@ func (s AccountService) AccountBalance(
 			return nil, WrapError(ErrCallInvalidParams, fmt.Errorf("%w: marshalling balanceOf call msg data failed", err))
 		}
 
-		contractAddress := ethcommon.HexToAddress(value.(string))
+		contractAddress := common.HexToAddress(value.(string))
 		callMsg := interfaces.CallMsg{To: &contractAddress, Data: data}
 		response, err := s.client.CallContract(ctx, callMsg, header.Number)
 		if err != nil {

--- a/service/service_account_test.go
+++ b/service/service_account_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanche-rosetta/constants"
@@ -40,8 +40,8 @@ func TestAccountBalance(t *testing.T) {
 
 		resp, err := service.AccountBalance(context.Background(), req)
 
-		assert.Nil(t, err)
-		assert.Equal(t, expectedResp, resp)
+		require.Nil(t, err)
+		require.Equal(t, expectedResp, resp)
 	})
 
 	t.Run("c-chain atomic request is delegated to c-chain atomic tx backend", func(t *testing.T) {
@@ -61,8 +61,8 @@ func TestAccountBalance(t *testing.T) {
 
 		resp, err := service.AccountBalance(context.Background(), req)
 
-		assert.Nil(t, err)
-		assert.Equal(t, expectedResp, resp)
+		require.Nil(t, err)
+		require.Equal(t, expectedResp, resp)
 	})
 }
 
@@ -96,8 +96,8 @@ func TestAccountCoins(t *testing.T) {
 
 		resp, err := service.AccountCoins(context.Background(), req)
 
-		assert.Nil(t, err)
-		assert.Equal(t, expectedResp, resp)
+		require.Nil(t, err)
+		require.Equal(t, expectedResp, resp)
 	})
 
 	t.Run("c-chain atomic request is delegated to c-chain atomic tx backend", func(t *testing.T) {
@@ -118,8 +118,8 @@ func TestAccountCoins(t *testing.T) {
 
 		resp, err := service.AccountCoins(context.Background(), req)
 
-		assert.Nil(t, err)
-		assert.Equal(t, expectedResp, resp)
+		require.Nil(t, err)
+		require.Equal(t, expectedResp, resp)
 	})
 
 	t.Run("c-chain regular request is not supported", func(t *testing.T) {
@@ -137,7 +137,7 @@ func TestAccountCoins(t *testing.T) {
 
 		resp, err := service.AccountCoins(context.Background(), req)
 
-		assert.Equal(t, ErrNotImplemented, err)
-		assert.Nil(t, resp)
+		require.Equal(t, ErrNotImplemented, err)
+		require.Nil(t, resp)
 	})
 }

--- a/service/service_block.go
+++ b/service/service_block.go
@@ -6,17 +6,17 @@ import (
 	"strings"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/coreth/core"
 	"github.com/coinbase/rosetta-sdk-go/server"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/coinbase/rosetta-sdk-go/utils"
 
-	"github.com/ava-labs/coreth/core"
-	corethTypes "github.com/ava-labs/coreth/core/types"
-	ethcommon "github.com/ethereum/go-ethereum/common"
-
 	"github.com/ava-labs/avalanche-rosetta/client"
 	"github.com/ava-labs/avalanche-rosetta/constants"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
+
+	ethtypes "github.com/ava-labs/coreth/core/types"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 // BlockBackend represents a backend that implements /block family of apis for a subset of requests
@@ -86,7 +86,7 @@ func (s *BlockService) Block(
 	var (
 		blockIdentifier       *types.BlockIdentifier
 		parentBlockIdentifier *types.BlockIdentifier
-		block                 *corethTypes.Block
+		block                 *ethtypes.Block
 		err                   error
 	)
 
@@ -190,7 +190,7 @@ func (s *BlockService) BlockTransaction(
 
 func (s *BlockService) fetchTransactions(
 	ctx context.Context,
-	block *corethTypes.Block,
+	block *ethtypes.Block,
 ) ([]*types.Transaction, *types.Error) {
 	transactions := []*types.Transaction{}
 
@@ -213,8 +213,8 @@ func (s *BlockService) fetchTransactions(
 
 func (s *BlockService) fetchTransaction(
 	ctx context.Context,
-	tx *corethTypes.Transaction,
-	header *corethTypes.Header,
+	tx *ethtypes.Transaction,
+	header *ethtypes.Header,
 	trace *client.Call,
 	flattened []*client.FlatCall,
 ) (*types.Transaction, *types.Error) {
@@ -238,7 +238,7 @@ func (s *BlockService) fetchTransaction(
 
 func (s *BlockService) parseCrossChainTransactions(
 	networkIdentifier *types.NetworkIdentifier,
-	block *corethTypes.Block,
+	block *ethtypes.Block,
 ) ([]*types.Transaction, *types.Error) {
 	result := []*types.Transaction{}
 

--- a/service/service_block.go
+++ b/service/service_block.go
@@ -10,13 +10,13 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/server"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/coinbase/rosetta-sdk-go/utils"
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ava-labs/avalanche-rosetta/client"
 	"github.com/ava-labs/avalanche-rosetta/constants"
 	"github.com/ava-labs/avalanche-rosetta/mapper"
 
 	ethtypes "github.com/ava-labs/coreth/core/types"
-	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 // BlockBackend represents a backend that implements /block family of apis for a subset of requests
@@ -91,7 +91,7 @@ func (s *BlockService) Block(
 	)
 
 	if hash := request.BlockIdentifier.Hash; hash != nil {
-		block, err = s.client.BlockByHash(ctx, ethcommon.HexToHash(*hash))
+		block, err = s.client.BlockByHash(ctx, common.HexToHash(*hash))
 	} else if index := request.BlockIdentifier.Index; block == nil && index != nil {
 		block, err = s.client.BlockByNumber(ctx, big.NewInt(*index))
 	}
@@ -159,12 +159,12 @@ func (s *BlockService) BlockTransaction(
 		return s.pChainBackend.BlockTransaction(ctx, request)
 	}
 
-	header, err := s.client.HeaderByHash(ctx, ethcommon.HexToHash(request.BlockIdentifier.Hash))
+	header, err := s.client.HeaderByHash(ctx, common.HexToHash(request.BlockIdentifier.Hash))
 	if err != nil {
 		return nil, WrapError(ErrClientError, err)
 	}
 
-	hash := ethcommon.HexToHash(request.TransactionIdentifier.Hash)
+	hash := common.HexToHash(request.TransactionIdentifier.Hash)
 	tx, pending, err := s.client.TransactionByHash(ctx, hash)
 	if err != nil {
 		return nil, WrapError(ErrClientError, err)

--- a/service/service_call.go
+++ b/service/service_call.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/ava-labs/avalanche-rosetta/client"
 	"github.com/coinbase/rosetta-sdk-go/server"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ava-labs/avalanche-rosetta/client"
 )
 
 // CallService implements /call/* endpoints

--- a/service/service_construction.go
+++ b/service/service_construction.go
@@ -1428,10 +1428,6 @@ func (s ConstructionService) CreateGenericContractCallOperationDescription(opera
 		return nil, errors.New("for generic call both values should be zero")
 	}
 
-	return s.createOperationDescriptionContractCall(), nil
-}
-
-func (ConstructionService) createOperationDescriptionContractCall() []*parser.OperationDescription {
 	return []*parser.OperationDescription{
 		{
 			Type: mapper.OpCall,
@@ -1453,7 +1449,7 @@ func (ConstructionService) createOperationDescriptionContractCall() []*parser.Op
 				Sign:   parser.AnyAmountSign,
 			},
 		},
-	}
+	}, nil
 }
 
 func generateErc20TransferData(toAddress string, value *big.Int) []byte {

--- a/service/service_construction.go
+++ b/service/service_construction.go
@@ -667,7 +667,7 @@ func (s ConstructionService) ConstructionPayloads(
 func (s ConstructionService) createTransferPayload(
 	req *types.ConstructionPayloadsRequest,
 ) (*ethtypes.Transaction, *transaction, *string, *types.Error) {
-	operationDescriptions, err := s.CreateTransferOperationDescription(req.Operations)
+	operationDescriptions, err := createTransferOperationDescription(req.Operations)
 	if err != nil {
 		return nil, nil, nil, WrapError(ErrInvalidInput, err.Error())
 	}
@@ -970,7 +970,7 @@ func (s ConstructionService) ConstructionPreprocess(
 			return nil, terr
 		}
 	default:
-		operationDescriptions, err = s.CreateTransferOperationDescription(req.Operations)
+		operationDescriptions, err = createTransferOperationDescription(req.Operations)
 		if err != nil {
 			return nil, WrapError(ErrInvalidInput, err.Error())
 		}
@@ -1074,7 +1074,7 @@ func (s ConstructionService) ConstructionSubmit(
 	}, nil
 }
 
-func (s ConstructionService) CreateTransferOperationDescription(
+func createTransferOperationDescription(
 	operations []*types.Operation,
 ) ([]*parser.OperationDescription, error) {
 	if len(operations) != 2 {

--- a/service/service_construction.go
+++ b/service/service_construction.go
@@ -1079,18 +1079,18 @@ func (s ConstructionService) CreateTransferOperationDescription(
 	operations []*types.Operation,
 ) ([]*parser.OperationDescription, error) {
 	if len(operations) != 2 {
-		return nil, fmt.Errorf("invalid number of operations")
+		return nil, errors.New("invalid number of operations")
 	}
 
 	firstCurrency := operations[0].Amount.Currency
 	secondCurrency := operations[1].Amount.Currency
 
 	if firstCurrency == nil || secondCurrency == nil {
-		return nil, fmt.Errorf("invalid currency on operation")
+		return nil, errors.New("invalid currency on operation")
 	}
 
 	if types.Hash(firstCurrency) != types.Hash(secondCurrency) {
-		return nil, fmt.Errorf("currency info doesn't match between the operations")
+		return nil, errors.New("currency info doesn't match between the operations")
 	}
 
 	if types.Hash(firstCurrency) == types.Hash(mapper.AvaxCurrency) {
@@ -1099,7 +1099,7 @@ func (s ConstructionService) CreateTransferOperationDescription(
 
 	// Not Native Avax, we require contractInfo in metadata.
 	if _, ok := firstCurrency.Metadata[mapper.ContractAddressMetadata].(string); !ok {
-		return nil, fmt.Errorf("non-native currency must have contractAddress in metadata")
+		return nil, errors.New("non-native currency must have contractAddress in metadata")
 	}
 
 	return s.createOperationDescriptionTransfer(firstCurrency, mapper.OpErc20Transfer), nil
@@ -1109,29 +1109,29 @@ func (s ConstructionService) CreateUnwrapOperationDescription(
 	operations []*types.Operation,
 ) ([]*parser.OperationDescription, error) {
 	if len(operations) != 1 {
-		return nil, fmt.Errorf("invalid number of operations")
+		return nil, errors.New("invalid number of operations")
 	}
 
 	firstCurrency := operations[0].Amount.Currency
 
 	if types.Hash(firstCurrency) == types.Hash(mapper.AvaxCurrency) {
-		return nil, fmt.Errorf("cannot unwrap native avax")
+		return nil, errors.New("cannot unwrap native avax")
 	}
 	tokenAddress, firstOk := firstCurrency.Metadata[mapper.ContractAddressMetadata].(string)
 
 	// Not Native Avax, we require contractInfo in metadata
 	if !firstOk {
-		return nil, fmt.Errorf("non-native currency must have contractAddress in metadata")
+		return nil, errors.New("non-native currency must have contractAddress in metadata")
 	}
 
 	if !mapper.EqualFoldContains(s.config.BridgeTokenList, tokenAddress) {
-		return nil, fmt.Errorf("only configured bridge tokens may use try to use unwrap function")
+		return nil, errors.New("only configured bridge tokens may use try to use unwrap function")
 	}
 
 	return s.createOperationDescriptionBridgeUnwrap(firstCurrency), nil
 }
 
-func (s ConstructionService) createTransferPreprocessOptions(
+func (ConstructionService) createTransferPreprocessOptions(
 	operationDescriptions []*parser.OperationDescription,
 	req *types.ConstructionPreprocessRequest,
 ) (*options, *types.Error) {
@@ -1169,7 +1169,7 @@ func (s ConstructionService) createTransferPreprocessOptions(
 	}, nil
 }
 
-func (s ConstructionService) createUnwrapPreprocessOptions(
+func (ConstructionService) createUnwrapPreprocessOptions(
 	operationDescriptions []*parser.OperationDescription,
 	req *types.ConstructionPreprocessRequest,
 ) (*options, *types.Error) {
@@ -1208,7 +1208,7 @@ func (s ConstructionService) createUnwrapPreprocessOptions(
 	}, nil
 }
 
-func (s ConstructionService) createOperationDescriptionTransfer(
+func (ConstructionService) createOperationDescriptionTransfer(
 	currency *types.Currency,
 	opCode string,
 ) []*parser.OperationDescription {
@@ -1238,7 +1238,7 @@ func (s ConstructionService) createOperationDescriptionTransfer(
 	}
 }
 
-func (s ConstructionService) createOperationDescriptionBridgeUnwrap(
+func (ConstructionService) createOperationDescriptionBridgeUnwrap(
 	currency *types.Currency,
 ) []*parser.OperationDescription {
 	return []*parser.OperationDescription{
@@ -1343,7 +1343,7 @@ func (s ConstructionService) getGenericContractCallGasLimit(
 	return gasLimit, nil
 }
 
-func (s ConstructionService) createGenericContractCallPreprocessOptions(
+func (ConstructionService) createGenericContractCallPreprocessOptions(
 	operationDescriptions []*parser.OperationDescription,
 	req *types.ConstructionPreprocessRequest,
 ) (*options, *types.Error) {
@@ -1401,17 +1401,17 @@ func (s ConstructionService) createGenericContractCallPreprocessOptions(
 
 func (s ConstructionService) CreateGenericContractCallOperationDescription(operations []*types.Operation) ([]*parser.OperationDescription, error) {
 	if len(operations) != 2 {
-		return nil, fmt.Errorf("invalid number of operations")
+		return nil, errors.New("invalid number of operations")
 	}
 
 	firstCurrency := operations[0].Amount.Currency
 	secondCurrency := operations[1].Amount.Currency
 	bigZero := big.NewInt(0)
 	if firstCurrency == nil || secondCurrency == nil {
-		return nil, fmt.Errorf("invalid currency on operation")
+		return nil, errors.New("invalid currency on operation")
 	}
 	if types.Hash(firstCurrency) != types.Hash(secondCurrency) {
-		return nil, fmt.Errorf("from and to currencies are not equal")
+		return nil, errors.New("from and to currencies are not equal")
 	}
 
 	i, ok := new(big.Int).SetString(operations[0].Amount.Value, base10)
@@ -1419,20 +1419,20 @@ func (s ConstructionService) CreateGenericContractCallOperationDescription(opera
 		return nil, errors.New("operation 0 does not have a valid amount")
 	}
 	if i.Cmp(bigZero) != 0 {
-		return nil, fmt.Errorf("for generic call both values should be zero")
+		return nil, errors.New("for generic call both values should be zero")
 	}
 	j, ok := new(big.Int).SetString(operations[1].Amount.Value, base10)
 	if !ok {
 		return nil, errors.New("operation 1 does not have a valid amount")
 	}
 	if j.Cmp(bigZero) != 0 {
-		return nil, fmt.Errorf("for generic call both values should be zero")
+		return nil, errors.New("for generic call both values should be zero")
 	}
 
 	return s.createOperationDescriptionContractCall(), nil
 }
 
-func (s ConstructionService) createOperationDescriptionContractCall() []*parser.OperationDescription {
+func (ConstructionService) createOperationDescriptionContractCall() []*parser.OperationDescription {
 	return []*parser.OperationDescription{
 		{
 			Type: mapper.OpCall,
@@ -1486,10 +1486,10 @@ func generateBridgeUnwrapTransferData(value *big.Int, chainID *big.Int) []byte {
 
 func parseErc20TransferData(data []byte) (*ethcommon.Address, *big.Int, error) {
 	if len(data) != genericTransferBytesLength {
-		return nil, nil, fmt.Errorf("incorrect length for data array")
+		return nil, nil, errors.New("incorrect length for data array")
 	}
 	if hexutil.Encode(data[:4]) != transferMethodID {
-		return nil, nil, fmt.Errorf("incorrect methodID signature")
+		return nil, nil, errors.New("incorrect methodID signature")
 	}
 
 	address := ethcommon.BytesToAddress(data[5:36])
@@ -1499,17 +1499,17 @@ func parseErc20TransferData(data []byte) (*ethcommon.Address, *big.Int, error) {
 
 func parseUnwrapData(data []byte) (*big.Int, *big.Int, error) {
 	if len(data) != genericUnwrapBytesLength {
-		return nil, nil, fmt.Errorf("incorrect length for data array")
+		return nil, nil, errors.New("incorrect length for data array")
 	}
 	if hexutil.Encode(data[:4]) != unwrapMethodID {
-		return nil, nil, fmt.Errorf("incorrect methodID signature")
+		return nil, nil, errors.New("incorrect methodID signature")
 	}
 
 	amount := new(big.Int).SetBytes(data[5:36])
 	chainID := new(big.Int).SetBytes(data[37:])
 
 	if chainID.Uint64() != 0 {
-		return nil, nil, fmt.Errorf("incorrect chainId value")
+		return nil, nil, errors.New("incorrect chainId value")
 	}
 
 	return amount, chainID, nil
@@ -1524,14 +1524,15 @@ func isUnwrapRequest(metadata map[string]interface{}) bool {
 
 func isGenericContractCall(metadata map[string]interface{}) bool {
 	if isUnwrap, ok := metadata["bridge_unwrap"]; ok {
-		if unwrapCall, isBool := isUnwrap.(bool); isBool {
-			if unwrapCall {
-				// If bridge_unwrap flag is true, we can return false right away, otherwise we should
-				// continue to check the method signature length.
-				return false
-			}
-		} else {
+		unwrapCall, isBool := isUnwrap.(bool)
+		if !isBool {
 			panic(fmt.Sprintf("bridge_unwrap value in the metadata must be boolean, got:%s", isUnwrap))
+		}
+
+		if unwrapCall {
+			// If bridge_unwrap flag is true, we can return false right away, otherwise we should
+			// continue to check the method signature length.
+			return false
 		}
 	}
 

--- a/service/service_construction_test.go
+++ b/service/service_construction_test.go
@@ -7,14 +7,15 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/ava-labs/avalanche-rosetta/client"
-	"github.com/ava-labs/avalanche-rosetta/mapper"
 	"github.com/ava-labs/coreth/interfaces"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
+	"github.com/ava-labs/avalanche-rosetta/client"
+	"github.com/ava-labs/avalanche-rosetta/mapper"
 
 	rosConst "github.com/ava-labs/avalanche-rosetta/constants"
 )
@@ -52,8 +53,8 @@ func TestConstructionMetadata(t *testing.T) {
 			context.Background(),
 			&types.ConstructionMetadataRequest{},
 		)
-		assert.Nil(t, resp)
-		assert.Equal(t, ErrUnavailableOffline.Code, err.Code)
+		require.Nil(t, resp)
+		require.Equal(t, ErrUnavailableOffline.Code, err.Code)
 	})
 
 	t.Run("requires from address", func(t *testing.T) {
@@ -61,9 +62,9 @@ func TestConstructionMetadata(t *testing.T) {
 			context.Background(),
 			&types.ConstructionMetadataRequest{},
 		)
-		assert.Nil(t, resp)
-		assert.Equal(t, ErrInvalidInput.Code, err.Code)
-		assert.Equal(t, "from address is not provided", err.Details["error"])
+		require.Nil(t, resp)
+		require.Equal(t, ErrInvalidInput.Code, err.Code)
+		require.Equal(t, "from address is not provided", err.Details["error"])
 	})
 
 	t.Run("basic native transfer", func(t *testing.T) {
@@ -104,13 +105,13 @@ func TestConstructionMetadata(t *testing.T) {
 				Options: input,
 			},
 		)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 		metadata := &metadata{
 			GasPrice: big.NewInt(1000000000),
 			GasLimit: 21_001,
 			Nonce:    0,
 		}
-		assert.Equal(t, &types.ConstructionMetadataResponse{
+		require.Equal(t, &types.ConstructionMetadataResponse{
 			Metadata: forceMarshalMap(t, metadata),
 			SuggestedFee: []*types.Amount{
 				{
@@ -173,14 +174,14 @@ func TestConstructionMetadata(t *testing.T) {
 				Options: input,
 			},
 		)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 		metadata := &metadata{
 			GasPrice:       big.NewInt(1000000000),
 			GasLimit:       21_001,
 			Nonce:          0,
 			UnwrapBridgeTx: true,
 		}
-		assert.Equal(t, &types.ConstructionMetadataResponse{
+		require.Equal(t, &types.ConstructionMetadataResponse{
 			Metadata: forceMarshalMap(t, metadata),
 			SuggestedFee: []*types.Amount{
 				{
@@ -239,13 +240,13 @@ func TestConstructionMetadata(t *testing.T) {
 				Options: input,
 			},
 		)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 		metadata := &metadata{
 			GasPrice: big.NewInt(1000000000),
 			GasLimit: 21_001,
 			Nonce:    0,
 		}
-		assert.Equal(t, &types.ConstructionMetadataResponse{
+		require.Equal(t, &types.ConstructionMetadataResponse{
 			Metadata: forceMarshalMap(t, metadata),
 			SuggestedFee: []*types.Amount{
 				{
@@ -272,17 +273,17 @@ func TestContructionHash(t *testing.T) {
 			context.Background(),
 			&types.ConstructionHashRequest{},
 		)
-		assert.Nil(t, resp)
-		assert.Equal(t, ErrInvalidInput.Code, err.Code)
-		assert.Equal(t, "signed transaction value is not provided", err.Details["error"])
+		require.Nil(t, resp)
+		require.Equal(t, ErrInvalidInput.Code, err.Code)
+		require.Equal(t, "signed transaction value is not provided", err.Details["error"])
 	})
 
 	t.Run("invalid transaction", func(t *testing.T) {
 		resp, err := service.ConstructionHash(context.Background(), &types.ConstructionHashRequest{
 			SignedTransaction: "{}",
 		})
-		assert.Nil(t, resp)
-		assert.Equal(t, ErrInvalidInput.Code, err.Code)
+		require.Nil(t, resp)
+		require.Equal(t, ErrInvalidInput.Code, err.Code)
 	})
 
 	t.Run("valid transaction", func(t *testing.T) {
@@ -290,13 +291,13 @@ func TestContructionHash(t *testing.T) {
 		request := signedTransactionWrapper{SignedTransaction: []byte(signed), Currency: nil}
 
 		json, marshalErr := json.Marshal(request)
-		assert.Nil(t, marshalErr)
+		require.Nil(t, marshalErr)
 
 		resp, err := service.ConstructionHash(context.Background(), &types.ConstructionHashRequest{
 			SignedTransaction: string(json),
 		})
-		assert.Nil(t, err)
-		assert.Equal(
+		require.Nil(t, err)
+		require.Equal(
 			t,
 			"0x92ea9280c1653aa9042c7a4d3a608c2149db45064609c18b270c7c73738e2a46",
 			resp.TransactionIdentifier.Hash,
@@ -309,8 +310,8 @@ func TestContructionHash(t *testing.T) {
 		resp, err := service.ConstructionHash(context.Background(), &types.ConstructionHashRequest{
 			SignedTransaction: signed,
 		})
-		assert.Nil(t, err)
-		assert.Equal(
+		require.Nil(t, err)
+		require.Equal(
 			t,
 			"0x92ea9280c1653aa9042c7a4d3a608c2149db45064609c18b270c7c73738e2a46",
 			resp.TransactionIdentifier.Hash,
@@ -323,8 +324,8 @@ func TestContructionHash(t *testing.T) {
 		resp, err := service.ConstructionHash(context.Background(), &types.ConstructionHashRequest{
 			SignedTransaction: signed,
 		})
-		assert.Contains(t, err.Details["error"].(string), "nonce")
-		assert.Nil(t, resp)
+		require.Contains(t, err.Details["error"].(string), "nonce")
+		require.Nil(t, resp)
 	})
 }
 
@@ -342,9 +343,9 @@ func TestConstructionDerive(t *testing.T) {
 			context.Background(),
 			&types.ConstructionDeriveRequest{},
 		)
-		assert.Nil(t, resp)
-		assert.Equal(t, ErrInvalidInput.Code, err.Code)
-		assert.Equal(t, "public key is not provided", err.Details["error"])
+		require.Nil(t, resp)
+		require.Equal(t, ErrInvalidInput.Code, err.Code)
+		require.Equal(t, "public key is not provided", err.Details["error"])
 	})
 
 	t.Run("invalid public key", func(t *testing.T) {
@@ -357,9 +358,9 @@ func TestConstructionDerive(t *testing.T) {
 				},
 			},
 		)
-		assert.Nil(t, resp)
-		assert.Equal(t, ErrInvalidInput.Code, err.Code)
-		assert.Equal(t, "invalid public key", err.Details["error"])
+		require.Nil(t, resp)
+		require.Equal(t, ErrInvalidInput.Code, err.Code)
+		require.Equal(t, "invalid public key", err.Details["error"])
 	})
 
 	t.Run("valid public key", func(t *testing.T) {
@@ -375,8 +376,8 @@ func TestConstructionDerive(t *testing.T) {
 				},
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(
+		require.Nil(t, err)
+		require.Equal(
 			t,
 			"0x156daFC6e9A1304fD5C9AB686acB4B3c802FE3f7",
 			resp.AccountIdentifier.Address,
@@ -386,10 +387,7 @@ func TestConstructionDerive(t *testing.T) {
 
 func forceMarshalMap(t *testing.T, i interface{}) map[string]interface{} {
 	m, err := mapper.MarshalJSONMap(i)
-	if err != nil {
-		t.Fatalf("could not marshal map %s", types.PrintStruct(i))
-	}
-
+	require.NoError(t, err)
 	return m
 }
 
@@ -414,7 +412,7 @@ func TestPreprocessMetadata(t *testing.T) {
 		unclearIntent := `[{"operation_identifier":{"index":0},"type":"CALL","account":{"address":"0xe3a5B4d7f79d64088C8d4ef153A7DDe2B2d47309"},"amount":{"value":"-42894881044106498","currency":{"symbol":"AVAX","decimals":18}}},{"operation_identifier":{"index":1},"type":"CALL","account":{"address":"0x57B414a0332B5CaB885a451c2a28a07d1e9b8a8d"},"amount":{"value":"42894881044106498","currency":{"symbol":"NOAX","decimals":18}}}]`
 
 		var ops []*types.Operation
-		assert.NoError(t, json.Unmarshal([]byte(unclearIntent), &ops))
+		require.NoError(t, json.Unmarshal([]byte(unclearIntent), &ops))
 		preprocessResponse, err := service.ConstructionPreprocess(
 			ctx,
 			&types.ConstructionPreprocessRequest{
@@ -422,12 +420,12 @@ func TestPreprocessMetadata(t *testing.T) {
 				Operations:        ops,
 			},
 		)
-		assert.Nil(t, preprocessResponse)
-		assert.Equal(t, "currency info doesn't match between the operations", err.Details["error"])
+		require.Nil(t, preprocessResponse)
+		require.Equal(t, "currency info doesn't match between the operations", err.Details["error"])
 	})
 	t.Run("basic flow", func(t *testing.T) {
 		var ops []*types.Operation
-		assert.NoError(t, json.Unmarshal([]byte(intent), &ops))
+		require.NoError(t, json.Unmarshal([]byte(intent), &ops))
 		preprocessResponse, err := service.ConstructionPreprocess(
 			ctx,
 			&types.ConstructionPreprocessRequest{
@@ -435,11 +433,11 @@ func TestPreprocessMetadata(t *testing.T) {
 				Operations:        ops,
 			},
 		)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 		optionsRaw := `{"from":"0xe3a5B4d7f79d64088C8d4ef153A7DDe2B2d47309","to":"0x57B414a0332B5CaB885a451c2a28a07d1e9b8a8d","value":"0x9864aac3510d02", "currency":{"symbol":"AVAX","decimals":18}}`
 		var opt options
-		assert.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
-		assert.Equal(t, &types.ConstructionPreprocessResponse{
+		require.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
+		require.Equal(t, &types.ConstructionPreprocessResponse{
 			Options: forceMarshalMap(t, &opt),
 		}, preprocessResponse)
 
@@ -482,8 +480,8 @@ func TestPreprocessMetadata(t *testing.T) {
 				Options:           forceMarshalMap(t, &opt),
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, &types.ConstructionMetadataResponse{
+		require.Nil(t, err)
+		require.Equal(t, &types.ConstructionMetadataResponse{
 			Metadata: forceMarshalMap(t, metadata),
 			SuggestedFee: []*types.Amount{
 				{
@@ -496,11 +494,11 @@ func TestPreprocessMetadata(t *testing.T) {
 
 	t.Run("basic flow (backwards compatible)", func(t *testing.T) {
 		var ops []*types.Operation
-		assert.NoError(t, json.Unmarshal([]byte(intent), &ops))
+		require.NoError(t, json.Unmarshal([]byte(intent), &ops))
 
 		optionsRaw := `{"from":"0xe3a5B4d7f79d64088C8d4ef153A7DDe2B2d47309"}`
 		var opt options
-		assert.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
+		require.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
 
 		metadata := &metadata{
 			GasPrice: big.NewInt(1000000000),
@@ -529,8 +527,8 @@ func TestPreprocessMetadata(t *testing.T) {
 				Options:           forceMarshalMap(t, &opt),
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, &types.ConstructionMetadataResponse{
+		require.Nil(t, err)
+		require.Equal(t, &types.ConstructionMetadataResponse{
 			Metadata: forceMarshalMap(t, metadata),
 			SuggestedFee: []*types.Amount{
 				{
@@ -543,7 +541,7 @@ func TestPreprocessMetadata(t *testing.T) {
 
 	t.Run("custom gas price flow", func(t *testing.T) {
 		var ops []*types.Operation
-		assert.NoError(t, json.Unmarshal([]byte(intent), &ops))
+		require.NoError(t, json.Unmarshal([]byte(intent), &ops))
 		preprocessResponse, err := service.ConstructionPreprocess(
 			ctx,
 			&types.ConstructionPreprocessRequest{
@@ -554,11 +552,11 @@ func TestPreprocessMetadata(t *testing.T) {
 				},
 			},
 		)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 		optionsRaw := `{"from":"0xe3a5B4d7f79d64088C8d4ef153A7DDe2B2d47309","to":"0x57B414a0332B5CaB885a451c2a28a07d1e9b8a8d","value":"0x9864aac3510d02","gas_price":"0x4190ab00", "currency":{"decimals":18, "symbol":"AVAX"}}`
 		var opt options
-		assert.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
-		assert.Equal(t, &types.ConstructionPreprocessResponse{
+		require.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
+		require.Equal(t, &types.ConstructionPreprocessResponse{
 			Options: forceMarshalMap(t, &opt),
 		}, preprocessResponse)
 
@@ -595,8 +593,8 @@ func TestPreprocessMetadata(t *testing.T) {
 				Options:           forceMarshalMap(t, &opt),
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, &types.ConstructionMetadataResponse{
+		require.Nil(t, err)
+		require.Equal(t, &types.ConstructionMetadataResponse{
 			Metadata: forceMarshalMap(t, metadata),
 			SuggestedFee: []*types.Amount{
 				{
@@ -609,7 +607,7 @@ func TestPreprocessMetadata(t *testing.T) {
 
 	t.Run("custom gas price flow (ignore multiplier)", func(t *testing.T) {
 		var ops []*types.Operation
-		assert.NoError(t, json.Unmarshal([]byte(intent), &ops))
+		require.NoError(t, json.Unmarshal([]byte(intent), &ops))
 		multiplier := float64(1.1)
 		preprocessResponse, err := service.ConstructionPreprocess(
 			ctx,
@@ -622,11 +620,11 @@ func TestPreprocessMetadata(t *testing.T) {
 				},
 			},
 		)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 		optionsRaw := `{"from":"0xe3a5B4d7f79d64088C8d4ef153A7DDe2B2d47309","to":"0x57B414a0332B5CaB885a451c2a28a07d1e9b8a8d","value":"0x9864aac3510d02","gas_price":"0x4190ab00","suggested_fee_multiplier":1.1, "currency":{"decimals":18, "symbol":"AVAX"}}`
 		var opt options
-		assert.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
-		assert.Equal(t, &types.ConstructionPreprocessResponse{
+		require.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
+		require.Equal(t, &types.ConstructionPreprocessResponse{
 			Options: forceMarshalMap(t, &opt),
 		}, preprocessResponse)
 
@@ -663,8 +661,8 @@ func TestPreprocessMetadata(t *testing.T) {
 				Options:           forceMarshalMap(t, &opt),
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, &types.ConstructionMetadataResponse{
+		require.Nil(t, err)
+		require.Equal(t, &types.ConstructionMetadataResponse{
 			Metadata: forceMarshalMap(t, metadata),
 			SuggestedFee: []*types.Amount{
 				{
@@ -677,7 +675,7 @@ func TestPreprocessMetadata(t *testing.T) {
 
 	t.Run("fee multiplier", func(t *testing.T) {
 		var ops []*types.Operation
-		assert.NoError(t, json.Unmarshal([]byte(intent), &ops))
+		require.NoError(t, json.Unmarshal([]byte(intent), &ops))
 		multiplier := float64(1.1)
 		preprocessResponse, err := service.ConstructionPreprocess(
 			ctx,
@@ -687,11 +685,11 @@ func TestPreprocessMetadata(t *testing.T) {
 				SuggestedFeeMultiplier: &multiplier,
 			},
 		)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 		optionsRaw := `{"from":"0xe3a5B4d7f79d64088C8d4ef153A7DDe2B2d47309","to":"0x57B414a0332B5CaB885a451c2a28a07d1e9b8a8d","value":"0x9864aac3510d02","suggested_fee_multiplier":1.1, "currency":{"decimals":18, "symbol":"AVAX"}}`
 		var opt options
-		assert.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
-		assert.Equal(t, &types.ConstructionPreprocessResponse{
+		require.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
+		require.Equal(t, &types.ConstructionPreprocessResponse{
 			Options: forceMarshalMap(t, &opt),
 		}, preprocessResponse)
 
@@ -734,8 +732,8 @@ func TestPreprocessMetadata(t *testing.T) {
 				Options:           forceMarshalMap(t, &opt),
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, &types.ConstructionMetadataResponse{
+		require.Nil(t, err)
+		require.Equal(t, &types.ConstructionMetadataResponse{
 			Metadata: forceMarshalMap(t, metadata),
 			SuggestedFee: []*types.Amount{
 				{
@@ -748,7 +746,7 @@ func TestPreprocessMetadata(t *testing.T) {
 
 	t.Run("custom nonce", func(t *testing.T) {
 		var ops []*types.Operation
-		assert.NoError(t, json.Unmarshal([]byte(intent), &ops))
+		require.NoError(t, json.Unmarshal([]byte(intent), &ops))
 		multiplier := float64(1.1)
 		preprocessResponse, err := service.ConstructionPreprocess(
 			ctx,
@@ -761,11 +759,11 @@ func TestPreprocessMetadata(t *testing.T) {
 				},
 			},
 		)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 		optionsRaw := `{"from":"0xe3a5B4d7f79d64088C8d4ef153A7DDe2B2d47309","to":"0x57B414a0332B5CaB885a451c2a28a07d1e9b8a8d","value":"0x9864aac3510d02","suggested_fee_multiplier":1.1, "nonce":"0x1", "currency":{"decimals":18, "symbol":"AVAX"}}`
 		var opt options
-		assert.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
-		assert.Equal(t, &types.ConstructionPreprocessResponse{
+		require.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
+		require.Equal(t, &types.ConstructionPreprocessResponse{
 			Options: forceMarshalMap(t, &opt),
 		}, preprocessResponse)
 
@@ -800,8 +798,8 @@ func TestPreprocessMetadata(t *testing.T) {
 				Options:           forceMarshalMap(t, &opt),
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, &types.ConstructionMetadataResponse{
+		require.Nil(t, err)
+		require.Equal(t, &types.ConstructionMetadataResponse{
 			Metadata: forceMarshalMap(t, metadata),
 			SuggestedFee: []*types.Amount{
 				{
@@ -814,7 +812,7 @@ func TestPreprocessMetadata(t *testing.T) {
 
 	t.Run("custom gas limit", func(t *testing.T) {
 		var ops []*types.Operation
-		assert.NoError(t, json.Unmarshal([]byte(intent), &ops))
+		require.NoError(t, json.Unmarshal([]byte(intent), &ops))
 		multiplier := float64(1.1)
 		preprocessResponse, err := service.ConstructionPreprocess(
 			ctx,
@@ -827,11 +825,11 @@ func TestPreprocessMetadata(t *testing.T) {
 				},
 			},
 		)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 		optionsRaw := `{"from":"0xe3a5B4d7f79d64088C8d4ef153A7DDe2B2d47309","to":"0x57B414a0332B5CaB885a451c2a28a07d1e9b8a8d","value":"0x9864aac3510d02","suggested_fee_multiplier":1.1,"gas_limit":"0x9c40", "currency":{"decimals":18, "symbol":"AVAX"}}`
 		var opt options
-		assert.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
-		assert.Equal(t, &types.ConstructionPreprocessResponse{
+		require.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
+		require.Equal(t, &types.ConstructionPreprocessResponse{
 			Options: forceMarshalMap(t, &opt),
 		}, preprocessResponse)
 
@@ -862,8 +860,8 @@ func TestPreprocessMetadata(t *testing.T) {
 				Options:           forceMarshalMap(t, &opt),
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, &types.ConstructionMetadataResponse{
+		require.Nil(t, err)
+		require.Equal(t, &types.ConstructionMetadataResponse{
 			Metadata: forceMarshalMap(t, metadata),
 			SuggestedFee: []*types.Amount{
 				{
@@ -885,7 +883,7 @@ func TestPreprocessMetadata(t *testing.T) {
 			cChainAtomicTxBackend: skippedBackend,
 		}
 		var ops []*types.Operation
-		assert.NoError(t, json.Unmarshal([]byte(erc20Intent), &ops))
+		require.NoError(t, json.Unmarshal([]byte(erc20Intent), &ops))
 		preprocessResponse, err := service.ConstructionPreprocess(
 			ctx,
 			&types.ConstructionPreprocessRequest{
@@ -893,11 +891,11 @@ func TestPreprocessMetadata(t *testing.T) {
 				Operations:        ops,
 			},
 		)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 		optionsRaw := `{"from":"0xe3a5B4d7f79d64088C8d4ef153A7DDe2B2d47309","to":"0x57B414a0332B5CaB885a451c2a28a07d1e9b8a8d","value":"0x9864aac3510d02", "currency":{"symbol":"TEST","decimals":18, "metadata": {"contractAddress": "0x30e5449b6712Adf4156c8c474250F6eA4400eB82"}}}`
 		var opt options
-		assert.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
-		assert.Equal(t, &types.ConstructionPreprocessResponse{
+		require.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
+		require.Equal(t, &types.ConstructionPreprocessResponse{
 			Options: forceMarshalMap(t, &opt),
 		}, preprocessResponse)
 
@@ -943,8 +941,8 @@ func TestPreprocessMetadata(t *testing.T) {
 				Options:           forceMarshalMap(t, &opt),
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, &types.ConstructionMetadataResponse{
+		require.Nil(t, err)
+		require.Equal(t, &types.ConstructionMetadataResponse{
 			Metadata: forceMarshalMap(t, metadata),
 			SuggestedFee: []*types.Amount{
 				{
@@ -971,7 +969,7 @@ func TestPreprocessMetadata(t *testing.T) {
 			cChainAtomicTxBackend: skippedBackend,
 		}
 		var ops []*types.Operation
-		assert.NoError(t, json.Unmarshal([]byte(unwrapIntent), &ops))
+		require.NoError(t, json.Unmarshal([]byte(unwrapIntent), &ops))
 
 		requestMetadata := map[string]interface{}{
 			"bridge_unwrap": true,
@@ -984,11 +982,11 @@ func TestPreprocessMetadata(t *testing.T) {
 				Metadata:          requestMetadata,
 			},
 		)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 		optionsRaw := `{"metadata": {"bridge_unwrap":true}, "from":"0xe3a5B4d7f79d64088C8d4ef153A7DDe2B2d47309","value":"0x9864aac3510d02", "currency":{"symbol":"TEST","decimals":18, "metadata": {"contractAddress": "0x30e5449b6712Adf4156c8c474250F6eA4400eB82"}}}`
 		var opt options
-		assert.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
-		assert.Equal(t, &types.ConstructionPreprocessResponse{
+		require.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
+		require.Equal(t, &types.ConstructionPreprocessResponse{
 			Options: forceMarshalMap(t, &opt),
 		}, preprocessResponse)
 
@@ -1035,8 +1033,8 @@ func TestPreprocessMetadata(t *testing.T) {
 				Options:           forceMarshalMap(t, &opt),
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, &types.ConstructionMetadataResponse{
+		require.Nil(t, err)
+		require.Equal(t, &types.ConstructionMetadataResponse{
 			Metadata: forceMarshalMap(t, metadata),
 			SuggestedFee: []*types.Amount{
 				{
@@ -1057,7 +1055,7 @@ func TestPreprocessMetadata(t *testing.T) {
 		}
 
 		var ops []*types.Operation
-		assert.NoError(t, json.Unmarshal([]byte(contractCallIntent), &ops))
+		require.NoError(t, json.Unmarshal([]byte(contractCallIntent), &ops))
 
 		requestMetadata := map[string]interface{}{
 			"bridge_unwrap":    false,
@@ -1073,12 +1071,12 @@ func TestPreprocessMetadata(t *testing.T) {
 				Metadata:          requestMetadata,
 			},
 		)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 
 		optionsRaw := `{"from":"0xe3a5B4d7f79d64088C8d4ef153A7DDe2B2d47309","to":"0x57B414a0332B5CaB885a451c2a28a07d1e9b8a8d","value":"0x0", "currency":{"symbol":"TEST","decimals":18}, "contract_address": "0x57B414a0332B5CaB885a451c2a28a07d1e9b8a8d", "method_signature": "deploy(bytes32,address,address,address,address)", "data": "0xb0d78b753100000000000000000000000000000000000000000000000000000000000000000000000000000000000000323e3ab04a3795ad79cc92378fcdb0a0aec51ba500000000000000000000000014e37c2e9cd255404bd35b4542fd9ccaa070aed6000000000000000000000000323e3ab04a3795ad79cc92378fcdb0a0aec51ba500000000000000000000000014e37c2e9cd255404bd35b4542fd9ccaa070aed6", "method_args":["0x3100000000000000000000000000000000000000000000000000000000000000","0x323e3ab04a3795ad79cc92378fcdb0a0aec51ba5","0x14e37c2e9cd255404bd35b4542fd9ccaa070aed6","0x323e3ab04a3795ad79cc92378fcdb0a0aec51ba5","0x14e37c2e9cd255404bd35b4542fd9ccaa070aed6"] }`
 		var opt options
-		assert.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
-		assert.Equal(t, &types.ConstructionPreprocessResponse{
+		require.NoError(t, json.Unmarshal([]byte(optionsRaw), &opt))
+		require.Equal(t, &types.ConstructionPreprocessResponse{
 			Options: forceMarshalMap(t, &opt),
 		}, preprocessResponse)
 
@@ -1128,8 +1126,8 @@ func TestPreprocessMetadata(t *testing.T) {
 				Options:           forceMarshalMap(t, &opt),
 			},
 		)
-		assert.Nil(t, err)
-		assert.Equal(t, &types.ConstructionMetadataResponse{
+		require.Nil(t, err)
+		require.Equal(t, &types.ConstructionMetadataResponse{
 			Metadata: forceMarshalMap(t, metadata),
 			SuggestedFee: []*types.Amount{
 				{
@@ -1193,8 +1191,8 @@ func TestBackendDelegations(t *testing.T) {
 			backends[idx].EXPECT().ConstructionDerive(gomock.Any(), req).Return(expectedResp, nil)
 			resp, err := offlineService.ConstructionDerive(context.Background(), req)
 
-			assert.Nil(t, err)
-			assert.Equal(t, expectedResp, resp)
+			require.Nil(t, err)
+			require.Equal(t, expectedResp, resp)
 		})
 
 		t.Run("Preprocess request is delegated to "+backendName, func(t *testing.T) {
@@ -1207,8 +1205,8 @@ func TestBackendDelegations(t *testing.T) {
 			backends[idx].EXPECT().ConstructionPreprocess(gomock.Any(), req).Return(expectedResp, nil)
 			resp, err := offlineService.ConstructionPreprocess(context.Background(), req)
 
-			assert.Nil(t, err)
-			assert.Equal(t, expectedResp, resp)
+			require.Nil(t, err)
+			require.Equal(t, expectedResp, resp)
 		})
 
 		t.Run("Metadata request is delegated to "+backendName, func(t *testing.T) {
@@ -1221,8 +1219,8 @@ func TestBackendDelegations(t *testing.T) {
 			backends[idx].EXPECT().ConstructionMetadata(gomock.Any(), req).Return(expectedResp, nil)
 			resp, err := onlineService.ConstructionMetadata(context.Background(), req)
 
-			assert.Nil(t, err)
-			assert.Equal(t, expectedResp, resp)
+			require.Nil(t, err)
+			require.Equal(t, expectedResp, resp)
 		})
 
 		t.Run("Payloads request is delegated to "+backendName, func(t *testing.T) {
@@ -1233,8 +1231,8 @@ func TestBackendDelegations(t *testing.T) {
 			backends[idx].EXPECT().ConstructionPayloads(gomock.Any(), req).Return(expectedResp, nil)
 			resp, err := offlineService.ConstructionPayloads(context.Background(), req)
 
-			assert.Nil(t, err)
-			assert.Equal(t, expectedResp, resp)
+			require.Nil(t, err)
+			require.Equal(t, expectedResp, resp)
 		})
 
 		t.Run("Combine request is delegated to "+backendName, func(t *testing.T) {
@@ -1248,8 +1246,8 @@ func TestBackendDelegations(t *testing.T) {
 			backends[idx].EXPECT().ConstructionCombine(gomock.Any(), req).Return(expectedResp, nil)
 			resp, err := offlineService.ConstructionCombine(context.Background(), req)
 
-			assert.Nil(t, err)
-			assert.Equal(t, expectedResp, resp)
+			require.Nil(t, err)
+			require.Equal(t, expectedResp, resp)
 		})
 
 		t.Run("Parse request is delegated to "+backendName, func(t *testing.T) {
@@ -1259,8 +1257,8 @@ func TestBackendDelegations(t *testing.T) {
 			backends[idx].EXPECT().ConstructionParse(gomock.Any(), req).Return(expectedResp, nil)
 			resp, err := offlineService.ConstructionParse(context.Background(), req)
 
-			assert.Nil(t, err)
-			assert.Equal(t, expectedResp, resp)
+			require.Nil(t, err)
+			require.Equal(t, expectedResp, resp)
 		})
 
 		t.Run("Hash request is delegated to "+backendName, func(t *testing.T) {
@@ -1272,8 +1270,8 @@ func TestBackendDelegations(t *testing.T) {
 			backends[idx].EXPECT().ConstructionHash(gomock.Any(), req).Return(expectedResp, nil)
 			resp, err := offlineService.ConstructionHash(context.Background(), req)
 
-			assert.Nil(t, err)
-			assert.Equal(t, expectedResp, resp)
+			require.Nil(t, err)
+			require.Equal(t, expectedResp, resp)
 		})
 
 		t.Run("Submit request is delegated to "+backendName, func(t *testing.T) {
@@ -1285,8 +1283,8 @@ func TestBackendDelegations(t *testing.T) {
 			backends[idx].EXPECT().ConstructionSubmit(gomock.Any(), req).Return(expectedResp, nil)
 			resp, err := onlineService.ConstructionSubmit(context.Background(), req)
 
-			assert.Nil(t, err)
-			assert.Equal(t, expectedResp, resp)
+			require.Nil(t, err)
+			require.Equal(t, expectedResp, resp)
 		})
 	}
 }

--- a/service/service_construction_test.go
+++ b/service/service_construction_test.go
@@ -290,13 +290,13 @@ func TestContructionHash(t *testing.T) {
 		signed := `{"nonce":"0x6","gasPrice":"0x6d6e2edc00","gas":"0x5208","to":"0x85ad9d1fcf50b72255e4288dca0ad29f5f509409","value":"0xde0b6b3a7640000","input":"0x","v":"0x150f6","r":"0x64d46cc17cbdbcf73b204a6979172eb3148237ecd369181b105e92b0d7fa49a7","s":"0x285063de57245f532a14b13f605bed047a9d20ebfd0db28e01bc8cc9eaac40ee","hash":"0x92ea9280c1653aa9042c7a4d3a608c2149db45064609c18b270c7c73738e2a46"}`
 		request := signedTransactionWrapper{SignedTransaction: []byte(signed), Currency: nil}
 
-		json, marshalErr := json.Marshal(request)
-		require.Nil(t, marshalErr)
+		json, err := json.Marshal(request)
+		require.NoError(t, err)
 
-		resp, err := service.ConstructionHash(context.Background(), &types.ConstructionHashRequest{
+		resp, terr := service.ConstructionHash(context.Background(), &types.ConstructionHashRequest{
 			SignedTransaction: string(json),
 		})
-		require.Nil(t, err)
+		require.Nil(t, terr)
 		require.Equal(
 			t,
 			"0x92ea9280c1653aa9042c7a4d3a608c2149db45064609c18b270c7c73738e2a46",

--- a/service/service_mempool.go
+++ b/service/service_mempool.go
@@ -47,7 +47,7 @@ func (s MempoolService) Mempool(
 }
 
 // MempoolTransaction implements the /mempool/transaction endpoint
-func (s MempoolService) MempoolTransaction(
+func (MempoolService) MempoolTransaction(
 	_ context.Context,
 	_ *types.MempoolTransactionRequest,
 ) (*types.MempoolTransactionResponse, *types.Error) {

--- a/service/types.go
+++ b/service/types.go
@@ -5,9 +5,10 @@ import (
 	"math/big"
 	"strconv"
 
-	"github.com/ava-labs/avalanche-rosetta/mapper"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/ava-labs/avalanche-rosetta/mapper"
 )
 
 const BalanceOfMethodPrefix = "0x70a08231000000000000000000000000"


### PR DESCRIPTION
Ports the latest `.golangci.yml` from avalanchego and applies fixes