### PR TITLE
Remove `pmapper.StakingOptions`

### DIFF
--- a/mapper/pchain/types.go
+++ b/mapper/pchain/types.go
@@ -78,18 +78,6 @@ type ImportExportOptions struct {
 	DestinationChain string `json:"destination_chain"`
 }
 
-// StakingOptions contain response fields returned by /construction/preprocess for P-chain AddValidator/AddDelegator transactions
-type StakingOptions struct {
-	NodeID          string   `json:"node_id"`
-	Start           uint64   `json:"start"`
-	End             uint64   `json:"end"`
-	Shares          uint32   `json:"shares"`
-	Memo            string   `json:"memo"`
-	Locktime        uint64   `json:"locktime"`
-	Threshold       uint32   `json:"threshold"`
-	RewardAddresses []string `json:"reward_addresses"`
-}
-
 // Metadata contains metadata values returned by /construction/metadata for P-chain transactions
 type Metadata struct {
 	NetworkID    uint32 `json:"network_id"`

--- a/service/backend/pchain/construction.go
+++ b/service/backend/pchain/construction.go
@@ -151,25 +151,13 @@ func (b *Backend) buildExportMetadata(ctx context.Context, options map[string]in
 }
 
 func buildStakingMetadata(options map[string]interface{}) (*pmapper.Metadata, *types.Amount, error) {
-	var preprocessOptions pmapper.StakingOptions
-	if err := mapper.UnmarshalJSONMap(options, &preprocessOptions); err != nil {
+	var stakingMetadata pmapper.StakingMetadata
+	if err := mapper.UnmarshalJSONMap(options, &stakingMetadata); err != nil {
 		return nil, nil, err
 	}
-
-	stakingMetadata := &pmapper.StakingMetadata{
-		NodeID:          preprocessOptions.NodeID,
-		Start:           preprocessOptions.Start,
-		End:             preprocessOptions.End,
-		Memo:            preprocessOptions.Memo,
-		Locktime:        preprocessOptions.Locktime,
-		Threshold:       preprocessOptions.Threshold,
-		RewardAddresses: preprocessOptions.RewardAddresses,
-		Shares:          preprocessOptions.Shares,
-	}
-
 	zeroAvax := mapper.AtomicAvaxAmount(big.NewInt(0))
 
-	return &pmapper.Metadata{StakingMetadata: stakingMetadata}, zeroAvax, nil
+	return &pmapper.Metadata{StakingMetadata: &stakingMetadata}, zeroAvax, nil
 }
 
 func (b *Backend) getBaseTxFee(ctx context.Context) (*types.Amount, error) {


### PR DESCRIPTION
This was a copy of `pmapper.StakingMetadata`. We can unmarshal into it directly