### PR TITLE
use custom eth client for block extra data

### DIFF
--- a/client/contract.go
+++ b/client/contract.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"github.com/ava-labs/avalanchego/cache/lru"
-	"github.com/ava-labs/coreth/ethclient"
+	ethclient "github.com/ava-labs/coreth/plugin/evm/customethclient"
 	"github.com/ava-labs/libevm/common"
 )
 

--- a/client/eth.go
+++ b/client/eth.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/ava-labs/coreth/eth/tracers"
-	"github.com/ava-labs/coreth/ethclient"
+	ethclient "github.com/ava-labs/coreth/plugin/evm/customethclient"
 	"github.com/ava-labs/coreth/rpc"
 )
 
@@ -31,7 +31,7 @@ func NewEthClient(ctx context.Context, endpoint string) (*EthClient, error) {
 	}
 
 	return &EthClient{
-		Client: *ethclient.NewClient(c),
+		Client: *ethclient.New(c),
 		rpc:    c,
 		traceConfig: &tracers.TraceConfig{
 			Timeout: &tracerTimeout,


### PR DESCRIPTION
We need to use [customethclient](https://github.com/ava-labs/coreth/blob/aac22d9/plugin/evm/customethclient/ethclient.go#L21-L22), a wrapper of standard ETH RPC client to get the extra data types (for Atomic transactions)

NOTE: `customethclient` can be removed in the incoming release in favour of `ethclient`